### PR TITLE
Fix screenshot in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 lichess mobile
 ==============
 
-![lichess mobile screenshots](https://raw.githubusercontent.com/veloce/lichobile/1.6.x/screens/3-screens.png)
+![lichess mobile screenshots](screens/3-screens.png)
 
 ### Official lichess.org mobile application for Android & iOS.
 


### PR DESCRIPTION
The screenshot link in the README is currently broken. By using the magic of relative paths, we make sure that the screenshots in the README stay up to date and visible, as long as they stay in the same directory.