### PR TITLE
Switch to HTTPS

### DIFF
--- a/project/env.json.example
+++ b/project/env.json.example
@@ -1,4 +1,4 @@
 {
-  "API_END_POINT": "en.stage.lichess.org",
-  "SOCKET_END_POINT": "socket.en.stage.lichess.org"
+  "API_END_POINT": "https://en.stage.lichess.org",
+  "SOCKET_END_POINT": "wss://socket.stage.lichess.org"
 }

--- a/project/src/index.html
+++ b/project/src/index.html
@@ -5,7 +5,7 @@
     <meta name="format-detection" content="telephone=no" />
     <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, width=device-width" />
     <!-- @if MODE!='dev' -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com; connect-src 'self' http://<!-- @echo API_END_POINT --> ws://<!-- @echo SOCKET_END_POINT -->:*; script-src 'self' 'unsafe-eval' 'unsafe-inline'; child-src 'self' blob: filesystem:; style-src 'self' 'unsafe-inline'; media-src 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com; connect-src 'self' <!-- @echo API_END_POINT --> <!-- @echo SOCKET_END_POINT -->:*; script-src 'self' 'unsafe-eval' 'unsafe-inline'; child-src 'self' blob: filesystem:; style-src 'self' 'unsafe-inline'; media-src 'self'">
     <!-- @endif -->
     <title>lichess.org</title>
     <link rel="stylesheet" type="text/css" href="css/normalize.css" />

--- a/project/src/js/http.js
+++ b/project/src/js/http.js
@@ -27,7 +27,7 @@ function xhrConfig(xhr) {
 export function request(url, opts, feedback, xhrConf) {
 
   var cfg = {
-    url: 'http://' + baseUrl + url,
+    url: baseUrl + url,
     method: 'GET',
     data: { },
     config: xhrConf || xhrConfig,

--- a/project/www/lib/socketWorker.js
+++ b/project/www/lib/socketWorker.js
@@ -34,7 +34,7 @@ function StrongSocket(clientId, socketEndPoint, url, version, settings) {
   this.autoReconnect = true;
   this.tryAnotherUrl = false;
   this.urlsPool = [this.socketEndPoint].concat(
-  [9021, 9022, 9023, 9024, 9025, 9026, 9027, 9028, 9029].map(
+  [9025, 9026, 9027, 9028, 9029].map(
     function(e) { return this.socketEndPoint + ':' + e; }.bind(this)
   ));
 
@@ -48,7 +48,7 @@ StrongSocket.prototype = {
     var self = this;
     self.destroy();
     self.autoReconnect = true;
-    var fullUrl = 'ws://' + self.baseUrl() + self.url + '?' + serializeQueryParameters(self.settings.params);
+    var fullUrl = self.baseUrl() + self.url + '?' + serializeQueryParameters(self.settings.params);
     self.debug('connection attempt to ' + fullUrl, true);
     try {
       if (WebSocket) self.ws = new WebSocket(fullUrl);
@@ -241,7 +241,7 @@ StrongSocket.prototype = {
   },
 
   baseUrl: function() {
-    if (this.socketEndPoint === 'socket.en.lichess.org') {
+    if (this.socketEndPoint === 'wss://socket.lichess.org') {
       if (!currentUrl) {
         currentUrl = this.urlsPool[0];
       } else if (this.tryAnotherUrl) {

--- a/tarifa.json
+++ b/tarifa.json
@@ -12,21 +12,21 @@
       "id": "org.lichess.mobileapp.dev",
       "product_name": "lichess_dev",
       "product_file_name": "lichess_dev",
-      "API_END_POINT": "en.stage.lichess.org",
-      "SOCKET_END_POINT": "socket.en.stage.lichess.org"
+      "API_END_POINT": "https://en.stage.lichess.org",
+      "SOCKET_END_POINT": "wss://socket.stage.lichess.org"
     },
     "stage": {
       "id": "org.lichess.mobileapp.stage",
       "product_name": "lichess_stage",
       "product_file_name": "lichess-stage",
-      "API_END_POINT": "en.stage.lichess.org",
-      "SOCKET_END_POINT": "socket.en.stage.lichess.org",
+      "API_END_POINT": "https://en.stage.lichess.org",
+      "SOCKET_END_POINT": "wss://socket.stage.lichess.org",
       "cordova": {
         "whitelist": [
           {
             "type": "access-origin",
             "origin": [
-              "http://en.stage.lichess.org"
+              "https://en.stage.lichess.org"
             ]
           }
         ]
@@ -36,15 +36,15 @@
       "id": "org.lichess.mobileapp.beta",
       "product_name": "lichess_beta",
       "product_file_name": "lichess-beta",
-      "API_END_POINT": "en.lichess.org",
-      "SOCKET_END_POINT": "socket.en.lichess.org",
+      "API_END_POINT": "https://en.lichess.org",
+      "SOCKET_END_POINT": "wss://socket.lichess.org",
       "beta": "1",
       "cordova": {
         "whitelist": [
           {
             "type": "access-origin",
             "origin": [
-              "http://en.lichess.org"
+              "https://en.lichess.org"
             ]
           }
         ]
@@ -54,8 +54,8 @@
       "id": "org.lichess.mobileapp",
       "product_name": "lichess",
       "product_file_name": "lichess-prod",
-      "API_END_POINT": "en.lichess.org",
-      "SOCKET_END_POINT": "socket.en.lichess.org",
+      "API_END_POINT": "https://en.lichess.org",
+      "SOCKET_END_POINT": "wss://socket.lichess.org",
       "GA_ID": "UA-7935029-3",
       "version": "4.0.1",
       "cordova": {
@@ -63,7 +63,7 @@
           {
             "type": "access-origin",
             "origin": [
-              "http://en.lichess.org"
+              "https://en.lichess.org"
             ]
           }
         ]


### PR DESCRIPTION
lichess.org is now using TLS \o/. The old API and socket endpoints will be available as long as we need them, but let's switch as soon as possible. This has been changed:

* http:// -> https://
* ws://socket.{lang}.lichess.org -> wss://socket.lichess.org
* Alternative ports 9025, 9026, 9027, 9028, 9029 now accept secure websockets

In this PR the protocol is now included in env.json, so you could still configure http:// for local testing. Every developer will have to update their env.json, though.

Tested:

* [X] Browser
* [x] Android (I can test later on 6.0.1)
* [ ] iPhone (Don't have it)