### PR TITLE
update color select only for variant standard

### DIFF
--- a/project/src/js/settings.js
+++ b/project/src/js/settings.js
@@ -231,7 +231,8 @@ export default {
       increment: localstorageprop('settings.game.human.increment', '0'),
       days: localstorageprop('settings.game.human.days', '2'),
       mode: localstorageprop('settings.game.human.mode', '0'),
-      membersOnly: localstorageprop('settings.game.human.membersOnly', false)
+      membersOnly: localstorageprop('settings.game.human.membersOnly', false),
+      color: localstorageprop('settings.game.human.color', 'random')
     },
 
     challenge: {

--- a/project/src/js/ui/newGameForm.js
+++ b/project/src/js/ui/newGameForm.js
@@ -86,8 +86,8 @@ function renderForm(formName, action, settingsObj, variants, timeModes) {
     ])
   ];
 
-  // AI only
-  if (settingsObj.color) {
+  // both human and AI
+  if (settingsObj.color && (settingsObj.variant() === '1' || settingsObj.level)) {
     const colors = [
       ['randomColor', 'random'],
       ['white', 'white'],

--- a/project/src/js/xhr.js
+++ b/project/src/js/xhr.js
@@ -34,7 +34,7 @@ export function seekGame() {
       days: config.days(),
       time: config.time(),
       increment: config.increment(),
-      color: 'random',
+      color: config.color(),
       mode: session.isConnected() ? config.mode() : '0',
       membersOnly: config.membersOnly(),
       ratingRange: config.ratingMin() + '-' + config.ratingMax()


### PR DESCRIPTION
> Color selection is not available for exotic variants in rated games, only casual. Antichess, Atomic, Horde, Racing Kings

now color select is only available for Variant Standard and AI Games 
(this is also possible on the website)