### PR TITLE
Fix for issue #273

### DIFF
--- a/project/src/js/settings.js
+++ b/project/src/js/settings.js
@@ -110,6 +110,7 @@ export default {
   otb: {
     flipPieces: localstorageprop('settings.otb.flipPieces', false),
     useSymmetric: localstorageprop('settings.otb.useSymmetric', true),
+    seeSymmetricCoordinates: localstorageprop('settings.otb.seeSymmetricCoordinates', true),
     variant: localstorageprop('settings.otb.variant', 'standard'),
     availableVariants: [
       ['Standard', 'standard'],

--- a/project/src/js/ui/otb/actions.js
+++ b/project/src/js/ui/otb/actions.js
@@ -13,6 +13,9 @@ function renderAlways() {
     )),
     m('div.action', formWidgets.renderCheckbox(
       i18n('Use Symmetric pieces'), 'useSymmetric', settings.otb.useSymmetric, m.redraw
+    )),
+    m('div.action', formWidgets.renderCheckbox(
+      i18n('See Symmetric coordinates'), 'seeSymmetricCoordinates', settings.otb.seeSymmetricCoordinates, m.redraw
     ))
   ];
 }

--- a/project/src/js/ui/otb/otbCtrl.js
+++ b/project/src/js/ui/otb/otbCtrl.js
@@ -109,6 +109,8 @@ export default function controller() {
     m.redraw();
   }.bind(this);
 
+  const seeSymmetricCoordinates = settings.otb.seeSymmetricCoordinates;
+
   this.startNewGame = function(setupFen) {
     const variant = settings.otb.variant();
     helper.analyticsTrackEvent('Offline Game', `New game ${variant}`);

--- a/project/src/js/ui/otb/otbCtrl.js
+++ b/project/src/js/ui/otb/otbCtrl.js
@@ -109,8 +109,6 @@ export default function controller() {
     m.redraw();
   }.bind(this);
 
-  const seeSymmetricCoordinates = settings.otb.seeSymmetricCoordinates;
-
   this.startNewGame = function(setupFen) {
     const variant = settings.otb.variant();
     helper.analyticsTrackEvent('Offline Game', `New game ${variant}`);

--- a/project/src/js/ui/otb/otbView.js
+++ b/project/src/js/ui/otb/otbView.js
@@ -43,6 +43,7 @@ export default function view(ctrl) {
 
 function renderContent(ctrl, pieceTheme) {
   const flip = settings.otb.flipPieces();
+  ctrl.chessground.data.symmetricCoordinates = settings.otb.seeSymmetricCoordinates();
   const wrapperClasses = helper.classSet({
     'otb': true,
     'mode_flip': flip,
@@ -85,4 +86,3 @@ function renderContent(ctrl, pieceTheme) {
       </section>
     ];
 }
-

--- a/project/src/styl/chessground-board.styl
+++ b/project/src/styl/chessground-board.styl
@@ -1,148 +1,268 @@
 // standard 2D boards
 .brown > .cg-board
   background-image url('../../images/board/brown.jpg')
-  > square[data-coord-x]
+  > square[data-coord-white-x]
     &:nth-child(odd)
       color rgba(#f0d9b5, 1)
     &:nth-child(even)
       color rgba(#b58863, 1)
-  > square[data-coord-y]
+  > square[data-coord-white-y]
     &:nth-child(8), &:nth-child(24), &:nth-child(40), &:nth-child(56)
       color rgba(#f0d9b5, 1)
     &:nth-child(16), &:nth-child(32), &:nth-child(48), &:nth-child(64)
       color rgba(#b58863, 1)
+  > square[data-coord-black-x]
+    &:nth-child(odd)
+      color rgba(#b58863, 1)
+    &:nth-child(even)
+      color rgba(#f0d9b5, 1)
+  > square[data-coord-black-y]
+    &:nth-child(1), &:nth-child(17), &:nth-child(33), &:nth-child(49)
+      color rgba(#b58863, 1)
+    &:nth-child(9), &:nth-child(25), &:nth-child(41), &:nth-child(57)
+      color rgba(#f0d9b5, 1)
 .blue > .cg-board
   background-image url('../../images/board/blue.jpg')
-  > square[data-coord-x]
+  > square[data-coord-white-x]
     &:nth-child(odd)
       color rgba(#dee3e6, 1)
     &:nth-child(even)
       color rgba(#8ca2ad, 1)
-  > square[data-coord-y]
+  > square[data-coord-white-y]
     &:nth-child(8), &:nth-child(24), &:nth-child(40), &:nth-child(56)
       color rgba(#dee3e6, 1)
     &:nth-child(16), &:nth-child(32), &:nth-child(48), &:nth-child(64)
       color rgba(#8ca2ad, 1)
+  > square[data-coord-black-x]
+    &:nth-child(odd)
+      color rgba(#8ca2ad, 1)
+    &:nth-child(even)
+      color rgba(#dee3e6, 1)
+  > square[data-coord-black-y]
+    &:nth-child(1), &:nth-child(17), &:nth-child(33), &:nth-child(49)
+      color rgba(#8ca2ad, 1)
+    &:nth-child(9), &:nth-child(25), &:nth-child(41), &:nth-child(57)
+      color rgba(#dee3e6, 1)
 .green > .cg-board
   background-image url('../../images/board/green.jpg')
-  > square[data-coord-x]
+  > square[data-coord-white-x]
     &:nth-child(odd)
       color rgba(#ffffdd, 1)
     &:nth-child(even)
       color rgba(#86a666, 1)
-  > square[data-coord-y]
+  > square[data-coord-white-y]
     &:nth-child(8), &:nth-child(24), &:nth-child(40), &:nth-child(56)
       color rgba(#ffffdd, 1)
     &:nth-child(16), &:nth-child(32), &:nth-child(48), &:nth-child(64)
       color rgba(#86a666, 1)
+  > square[data-coord-black-x]
+    &:nth-child(odd)
+      color rgba(#86a666, 1)
+    &:nth-child(even)
+      color rgba(#ffffdd, 1)
+  > square[data-coord-black-y]
+    &:nth-child(1), &:nth-child(17), &:nth-child(33), &:nth-child(49)
+      color rgba(#86a666, 1)
+    &:nth-child(9), &:nth-child(25), &:nth-child(41), &:nth-child(57)
+      color rgba(#ffffdd, 1)
 .purple > .cg-board
   background-image url('../../images/board/purple.jpg')
-  > square[data-coord-x]
+  > square[data-coord-white-x]
     &:nth-child(odd)
       color rgba(#9f90b0, 1)
     &:nth-child(even)
       color rgba(#7d4a8d, 1)
-  > square[data-coord-y]
+  > square[data-coord-white-y]
     &:nth-child(8), &:nth-child(24), &:nth-child(40), &:nth-child(56)
       color rgba(#9f90b0, 1)
     &:nth-child(16), &:nth-child(32), &:nth-child(48), &:nth-child(64)
       color rgba(#7d4a8d, 1)
+  > square[data-coord-black-x]
+    &:nth-child(odd)
+      color rgba(#7d4a8d, 1)
+    &:nth-child(even)
+      color rgba(#9f90b0, 1)
+  > square[data-coord-black-y]
+    &:nth-child(1), &:nth-child(17), &:nth-child(33), &:nth-child(49)
+      color rgba(#7d4a8d, 1)
+    &:nth-child(9), &:nth-child(25), &:nth-child(41), &:nth-child(57)
+      color rgba(#9f90b0, 1)
 .wood > .cg-board
   background-image url('../../images/board/wood.jpg')
-  > square[data-coord-x]
+  > square[data-coord-white-x]
     &:nth-child(odd)
       color rgba(#d29d51, 1)
     &:nth-child(even)
       color rgba(#985520, 1)
-  > square[data-coord-y]
+  > square[data-coord-white-y]
     &:nth-child(8), &:nth-child(24), &:nth-child(40), &:nth-child(56)
       color rgba(#d29d51, 1)
     &:nth-child(16), &:nth-child(32), &:nth-child(48), &:nth-child(64)
       color rgba(#985520, 1)
+  > square[data-coord-black-x]
+    &:nth-child(odd)
+      color rgba(#985520, 1)
+    &:nth-child(even)
+      color rgba(#d29d51, 1)
+  > square[data-coord-black-y]
+    &:nth-child(1), &:nth-child(17), &:nth-child(33), &:nth-child(49)
+      color rgba(#985520, 1)
+    &:nth-child(9), &:nth-child(25), &:nth-child(41), &:nth-child(57)
+      color rgba(#d29d51, 1)
 .wood2 > .cg-board
   background-image url('../../images/board/wood2.jpg')
-  > square[data-coord-x]
+  > square[data-coord-white-x]
     &:nth-child(odd)
       color rgba(#94794c, 1)
     &:nth-child(even)
       color rgba(darken(#836839, 20%), 1)
-  > square[data-coord-y]
+  > square[data-coord-white-y]
     &:nth-child(8), &:nth-child(24), &:nth-child(40), &:nth-child(56)
       color rgba(#94794c, 1)
     &:nth-child(16), &:nth-child(32), &:nth-child(48), &:nth-child(64)
       color rgba(darken(#836839, 20%), 1)
+  > square[data-coord-black-x]
+    &:nth-child(odd)
+      color rgba(#836839, 1)
+    &:nth-child(even)
+      color rgba(#94794c, 1)
+  > square[data-coord-black-y]
+    &:nth-child(1), &:nth-child(17), &:nth-child(33), &:nth-child(49)
+      color rgba(#836839, 1)
+    &:nth-child(9), &:nth-child(25), &:nth-child(41), &:nth-child(57)
+      color rgba(#94794c, 1)
 .wood3 > .cg-board
   background-image url('../../images/board/wood3.jpg')
-  > square[data-coord-x]
+  > square[data-coord-white-x]
     &:nth-child(odd)
       color rgba(#bdb3a7, 1)
     &:nth-child(even)
       color rgba(#91683a, 1)
-  > square[data-coord-y]
+  > square[data-coord-white-y]
     &:nth-child(8), &:nth-child(24), &:nth-child(40), &:nth-child(56)
       color rgba(#bdb3a7, 1)
     &:nth-child(16), &:nth-child(32), &:nth-child(48), &:nth-child(64)
       color rgba(#91683a, 1)
+  > square[data-coord-black-x]
+    &:nth-child(odd)
+      color rgba(#91683a, 1)
+    &:nth-child(even)
+      color rgba(#bdb3a7, 1)
+  > square[data-coord-black-y]
+    &:nth-child(1), &:nth-child(17), &:nth-child(33), &:nth-child(49)
+      color rgba(#91683a, 1)
+    &:nth-child(9), &:nth-child(25), &:nth-child(41), &:nth-child(57)
+      color rgba(#bdb3a7, 1)
 .maple > .cg-board
   background-image url('../../images/board/maple.jpg')
-  > square[data-coord-x]
+  > square[data-coord-white-x]
     &:nth-child(odd)
       color rgba(#ECCCA3, 1)
     &:nth-child(even)
       color rgba(#BB7D4A, 1)
-  > square[data-coord-y]
+  > square[data-coord-white-y]
     &:nth-child(8), &:nth-child(24), &:nth-child(40), &:nth-child(56)
       color rgba(#ECCCA3, 1)
     &:nth-child(16), &:nth-child(32), &:nth-child(48), &:nth-child(64)
       color rgba(#BB7D4A, 1)
+  > square[data-coord-black-x]
+    &:nth-child(odd)
+      color rgba(#BB7D4A, 1)
+    &:nth-child(even)
+      color rgba(#ECCCA3, 1)
+  > square[data-coord-black-y]
+    &:nth-child(1), &:nth-child(17), &:nth-child(33), &:nth-child(49)
+      color rgba(#BB7D4A, 1)
+    &:nth-child(9), &:nth-child(25), &:nth-child(41), &:nth-child(57)
+      color rgba(#ECCCA3, 1)
 .blue3 > .cg-board
   background-image url('../../images/board/blue3.jpg')
-  > square[data-coord-x]
+  > square[data-coord-white-x]
     &:nth-child(odd)
       color rgba(#c3cdd7, 1)
     &:nth-child(even)
       color rgba(#487aad, 1)
-  > square[data-coord-y]
+  > square[data-coord-white-y]
     &:nth-child(8), &:nth-child(24), &:nth-child(40), &:nth-child(56)
       color rgba(#c3cdd7, 1)
     &:nth-child(16), &:nth-child(32), &:nth-child(48), &:nth-child(64)
       color rgba(#487aad, 1)
+  > square[data-coord-black-x]
+    &:nth-child(odd)
+      color rgba(#487aad, 1)
+    &:nth-child(even)
+      color rgba(#c3cdd7, 1)
+  > square[data-coord-black-y]
+    &:nth-child(1), &:nth-child(17), &:nth-child(33), &:nth-child(49)
+      color rgba(#487aad, 1)
+    &:nth-child(9), &:nth-child(25), &:nth-child(41), &:nth-child(57)
+      color rgba(#c3cdd7, 1)
 .canvas > .cg-board
   background-image url('../../images/board/canvas.jpg')
-  > square[data-coord-x]
+  > square[data-coord-white-x]
     &:nth-child(odd)
       color rgba(#c3cdd7, 1)
     &:nth-child(even)
       color rgba(#7687a3, 1)
-  > square[data-coord-y]
+  > square[data-coord-white-y]
     &:nth-child(8), &:nth-child(24), &:nth-child(40), &:nth-child(56)
       color rgba(#c3cdd7, 1)
     &:nth-child(16), &:nth-child(32), &:nth-child(48), &:nth-child(64)
       color rgba(#7687a3, 1)
+  > square[data-coord-black-x]
+    &:nth-child(odd)
+      color rgba(#7687a3, 1)
+    &:nth-child(even)
+      color rgba(#c3cdd7, 1)
+  > square[data-coord-black-y]
+    &:nth-child(1), &:nth-child(17), &:nth-child(33), &:nth-child(49)
+      color rgba(#7687a3, 1)
+    &:nth-child(9), &:nth-child(25), &:nth-child(41), &:nth-child(57)
+      color rgba(#c3cdd7, 1)
 .grey > .cg-board
   background-image url('../../images/board/grey.jpg')
-  > square[data-coord-x]
+  > square[data-coord-white-x]
     &:nth-child(odd)
       color rgba(#a3a3a3, 1)
     &:nth-child(even)
       color rgba(#888888, 1)
-  > square[data-coord-y]
+  > square[data-coord-white-y]
     &:nth-child(8), &:nth-child(24), &:nth-child(40), &:nth-child(56)
       color rgba(#a3a3a3, 1)
     &:nth-child(16), &:nth-child(32), &:nth-child(48), &:nth-child(64)
       color rgba(#888888, 1)
+  > square[data-coord-black-x]
+    &:nth-child(odd)
+      color rgba(#888888, 1)
+    &:nth-child(even)
+      color rgba(#a3a3a3, 1)
+  > square[data-coord-black-y]
+    &:nth-child(1), &:nth-child(17), &:nth-child(33), &:nth-child(49)
+      color rgba(#888888, 1)
+    &:nth-child(9), &:nth-child(25), &:nth-child(41), &:nth-child(57)
+      color rgba(#a3a3a3, 1)
 .metal > .cg-board
   background-image url('../../images/board/metal.jpg')
-  > square[data-coord-x]
+  > square[data-coord-white-x]
     &:nth-child(odd)
       color rgba(#cecece, 1)
     &:nth-child(even)
       color rgba(#727272, 1)
-  > square[data-coord-y]
+  > square[data-coord-white-y]
     &:nth-child(8), &:nth-child(24), &:nth-child(40), &:nth-child(56)
       color rgba(#cecece, 1)
     &:nth-child(16), &:nth-child(32), &:nth-child(48), &:nth-child(64)
       color rgba(#727272, 1)
+  > square[data-coord-black-x]
+    &:nth-child(odd)
+      color rgba(#727272, 1)
+    &:nth-child(even)
+      color rgba(#cecece, 1)
+  > square[data-coord-black-y]
+    &:nth-child(1), &:nth-child(17), &:nth-child(33), &:nth-child(49)
+      color rgba(#727272, 1)
+    &:nth-child(9), &:nth-child(25), &:nth-child(41), &:nth-child(57)
+      color rgba(#cecece, 1)
 
 .kingOfTheHill > .cg-board:before
   width: 25%;

--- a/project/src/styl/chessground.styl
+++ b/project/src/styl/chessground.styl
@@ -33,7 +33,7 @@ square
   &.selected
     background-color rgba(216, 85, 0, 0.3)
 
-square[data-coord-x]:after, square[data-coord-y]:before
+square[data-coord-white-x]:after, square[data-coord-white-y]:before, square[data-coord-black-x]:after, square[data-coord-black-y]:before
   position absolute
   font-family Cousine
   font-weight bold
@@ -43,16 +43,27 @@ square[data-coord-x]:after, square[data-coord-y]:before
     font-size 15px
     line-height 15px
 
-
-square[data-coord-x]:after
-  left 1px
+square[data-coord-white-x]:after
+  right 1px
   bottom 0px
-  content attr(data-coord-x)
+  content attr(data-coord-white-x)
 
-square[data-coord-y]:before
+square[data-coord-white-y]:before
   right 1px
   top 1px
-  content attr(data-coord-y)
+  content attr(data-coord-white-y)
+
+square[data-coord-black-x]:after
+  left 1px
+  top 0px
+  content attr(data-coord-black-x)
+  transform: rotate(180deg)
+
+square[data-coord-black-y]:before
+  left 1px
+  bottom 0px
+  content attr(data-coord-black-y)
+  transform: rotate(180deg)
 
 piece
   position absolute


### PR DESCRIPTION
This is a fix for issue #273 
It requires another pull on the chessground repository (https://github.com/veloce/chessground-mobile/pull/1)

In order to not mess with the surrounding layout and keep maximum board space, coordinates are inside the squares.

ISSUE:
The board is not updated with `m.redraw` but getting out of OTB and in again does the trick.
