### PR TITLE
Update tablebase endpoint

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="format-detection" content="telephone=no" />
     <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, width=device-width" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' gap: data: https://ssl.gstatic.com; connect-src 'self' https://expl.lichess.org <!-- @echo API_END_POINT --> <!-- @echo SOCKET_END_POINT -->:*; script-src 'self' 'unsafe-eval' 'unsafe-inline'; child-src 'self' filesystem: gap://ready; style-src 'self' 'unsafe-inline'; media-src 'self'">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' gap: data: https://ssl.gstatic.com; connect-src 'self' https://expl.lichess.org https://tablebase.lichess.org <!-- @echo API_END_POINT --> <!-- @echo SOCKET_END_POINT -->:*; script-src 'self' 'unsafe-eval' 'unsafe-inline'; child-src 'self' filesystem: gap://ready; style-src 'self' 'unsafe-inline'; media-src 'self'">
     <title>Mobile app • lichess.org</title>
     <link rel="stylesheet" type="text/css" href="css/normalize.css" />
     <link rel="stylesheet" type="text/css" href="css/fa.css" />

--- a/src/js/ui/analyse/explorer/explorerCtrl.ts
+++ b/src/js/ui/analyse/explorer/explorerCtrl.ts
@@ -12,8 +12,7 @@ import { AnalyseCtrlInterface, ExplorerCtrlInterface, ExplorerData } from '../in
 function tablebaseRelevant(fen: string) {
   const parts = fen.split(/\s/);
   const pieceCount = parts[0].split(/[nbrqkp]/i).length - 1;
-  const castling = parts[2];
-  return pieceCount <= 6 && castling === '-';
+  return pieceCount <= 7;
 }
 
 export default function(root: AnalyseCtrlInterface, allow: boolean): ExplorerCtrlInterface {
@@ -81,7 +80,7 @@ export default function(root: AnalyseCtrlInterface, allow: boolean): ExplorerCtr
   }, 1000);
 
   const fetchTablebase = debounce((fen: string) => {
-    return tablebaseXhr(root.vm.step.fen)
+    return tablebaseXhr(effectiveVariant, root.vm.step.fen)
     .then((res: ExplorerData) => {
       res.tablebase = true;
       res.fen = fen;

--- a/src/js/ui/analyse/explorer/explorerView.tsx
+++ b/src/js/ui/analyse/explorer/explorerView.tsx
@@ -89,11 +89,12 @@ function show(ctrl: AnalyseCtrlInterface) {
     if (moves.length) {
       return (
         <div key="explorer-tablebase" className="data scrollerWrapper">
-          {showTablebase(ctrl, 'Winning', moves.filter((move: ExplorerMove) => move.real_wdl === -2), data.fen)}
-          {showTablebase(ctrl, 'Win prevented by 50-move rule', moves.filter((move: ExplorerMove) => move.real_wdl === -1), data.fen)}
-          {showTablebase(ctrl, 'Drawn', moves.filter((move: ExplorerMove) => move.real_wdl === 0), data.fen)}
-          {showTablebase(ctrl, 'Loss saved by 50-move rule', moves.filter((move: ExplorerMove) => move.real_wdl === 1), data.fen)}
-          {showTablebase(ctrl, 'Losing', moves.filter((move: ExplorerMove) => move.real_wdl === 2), data.fen)}
+          {showTablebase(ctrl, 'Winning', moves.filter((move: ExplorerMove) => move.wdl === -2), data.fen)}
+          {showTablebase(ctrl, 'Unknown', moves.filter((move: ExplorerMove) => move.wdl === null), data.fen)}
+          {showTablebase(ctrl, 'Win prevented by 50-move rule', moves.filter((move: ExplorerMove) => move.wdl === -1), data.fen)}
+          {showTablebase(ctrl, 'Drawn', moves.filter((move: ExplorerMove) => move.wdl === 0), data.fen)}
+          {showTablebase(ctrl, 'Loss saved by 50-move rule', moves.filter((move: ExplorerMove) => move.wdl === 1), data.fen)}
+          {showTablebase(ctrl, 'Losing', moves.filter((move: ExplorerMove) => move.wdl === 2), data.fen)}
         </div>
       );
     }

--- a/src/js/ui/analyse/explorer/explorerXhr.ts
+++ b/src/js/ui/analyse/explorer/explorerXhr.ts
@@ -1,6 +1,7 @@
 import { fetchJSON } from '../../../http';
 
-const endpoint = 'https://expl.lichess.org';
+const explorerEndpoint = 'https://expl.lichess.org';
+const tablebaseEndpoint = 'https://tablebase.lichess.org';
 
 export function openingXhr(variant: VariantKey, fen: string, config: any, withGames: boolean) {
   let url: string;
@@ -19,7 +20,7 @@ export function openingXhr(variant: VariantKey, fen: string, config: any, withGa
     params['speeds[]'] = config.speed.selected();
     params['ratings[]'] = config.rating.selected();
   }
-  return fetchJSON(endpoint + url, {
+  return fetchJSON(explorerEndpoint + url, {
     headers: {
       'Accept': 'application/json, text/*'
     },
@@ -27,8 +28,8 @@ export function openingXhr(variant: VariantKey, fen: string, config: any, withGa
   });
 }
 
-export function tablebaseXhr(fen: string) {
-  return fetchJSON(endpoint + '/tablebase', {
+export function tablebaseXhr(variant: VariantKey, fen: string) {
+  return fetchJSON(tablebaseEndpoint + '/' + variant, {
     headers: {
       'Accept': 'application/json, text/*'
     },


### PR DESCRIPTION
There's a new tablebase endpoint.

Changes:

* Moved to new server that has space for variant tablebases in the future
* Start querying the 6 man tablebases when there are 7 pieces on the board to display winning transitions
* API sends less unused information, `real_wdl` -> `wdl`

We can keep the old endpoint up as long as we like.