### PR TITLE
Return only friends from search until no friends match. Then search everyone.

### DIFF
--- a/src/js/ui/players/playerXhr.ts
+++ b/src/js/ui/players/playerXhr.ts
@@ -2,7 +2,7 @@ import { fetchJSON } from '../../http';
 import { User, Rankings } from '../../lichess/interfaces/user'
 
 export function autocomplete(term: string): Promise<Array<string>> {
-  return fetchJSON('/player/autocomplete', { query: { term }});
+  return fetchJSON('/player/autocomplete?friend=1', { query: { term }});
 }
 
 export function suggestions(userId: string) {


### PR DESCRIPTION
The `friend` flag is a neat option that @ornicar showed me. It's a nice way to prioritize what most users are doing most of the time (searching for a friend), but still pulling up other results when the user enters a prefix that doesn't match any of their friends.