### PR TITLE
Ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ npm-debug.log
 /node_modules
 /env.json
 /env-*.json
+/package-lock.json
 
 .DS_Store
 .tags


### PR DESCRIPTION
The file `package-lock.json` is sometimes created by npm. Without adding it to `.gitignore`, I can't do a simple `git add -A` to add all my real code changes.