### PR TITLE
Handle position deep links

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -87,6 +87,7 @@
             <path event="analysisPosition" url="/analysis/*" />
             <path event="challenge" url="/challenge/*" />
             <path event="editor" url="/editor" />
+            <path event="editorPosition" url="/editor/*" />
             <path event="inbox" url="/inbox" />
             <path event="inboxNew" url="/inbox/new" />
             <path event="players" url="/player" />

--- a/config.xml
+++ b/config.xml
@@ -84,6 +84,7 @@
     <universal-links>
         <host name="lichess.org" scheme="https">
             <path event="analysis" url="/analysis" />
+            <path event="analysisPosition" url="/analysis/*" />
             <path event="challenge" url="/challenge/*" />
             <path event="editor" url="/editor" />
             <path event="inbox" url="/inbox" />

--- a/deepLinkTest.html
+++ b/deepLinkTest.html
@@ -18,20 +18,20 @@
     </ul>
     <h1>lichess deep links using normal "https://" scheme</h1>
     <ul>
-      <li><a href="https://en.lichess.org/analysis">https://en.lichess.org/analysis</a></li>
-      <li><a href="https://en.lichess.org/editor">https://en.lichess.org/editor</a></li>
-      <li><a href="https://en.lichess.org/inbox">https://en.lichess.org/inbox</a></li>
-      <li><a href="https://en.lichess.org/inbox/new">https://en.lichess.org/inbox/new</a></li>
-      <li><a href="https://en.lichess.org/player">https://en.lichess.org/player</a></li>
-      <li><a href="https://en.lichess.org/b9G5UVbM">https://en.lichess.org/b9G5UVbM</a></li>
-      <li><a href="https://en.lichess.org/tournament/QsEkR4FO">https://en.lichess.org/tournament/QsEkR4FO</a></li>
-      <li><a href="https://en.lichess.org/tournament">https://en.lichess.org/tournament</a></li>
-      <li><a href="https://en.lichess.org/training/4760">https://en.lichess.org/training/4760</a></li>
-      <li><a href="https://en.lichess.org/training">https://en.lichess.org/training</a></li>
-      <li><a href="https://en.lichess.org/tv">https://en.lichess.org/tv</a></li>
-      <li><a href="https://en.lichess.org/tv/bullet">https://en.lichess.org/tv/bullet</a></li>
-      <li><a href="https://en.lichess.org/@/freefal">https://en.lichess.org/@/freefal</a></li>
-      <li><a href="https://en.lichess.org/@/freefal/perf/bullet">https://en.lichess.org/@/freefal/perf/bullet</a></li>
+      <li><a href="https://lichess.org/analysis">https://lichess.org/analysis</a></li>
+      <li><a href="https://lichess.org/editor">https://lichess.org/editor</a></li>
+      <li><a href="https://lichess.org/inbox">https://lichess.org/inbox</a></li>
+      <li><a href="https://lichess.org/inbox/new">https://lichess.org/inbox/new</a></li>
+      <li><a href="https://lichess.org/player">https://lichess.org/player</a></li>
+      <li><a href="https://lichess.org/b9G5UVbM">https://lichess.org/b9G5UVbM</a></li>
+      <li><a href="https://lichess.org/tournament/QsEkR4FO">https://lichess.org/tournament/QsEkR4FO</a></li>
+      <li><a href="https://lichess.org/tournament">https://lichess.org/tournament</a></li>
+      <li><a href="https://lichess.org/training/4760">https://lichess.org/training/4760</a></li>
+      <li><a href="https://lichess.org/training">https://lichess.org/training</a></li>
+      <li><a href="https://lichess.org/tv">https://lichess.org/tv</a></li>
+      <li><a href="https://lichess.org/tv/bullet">https://lichess.org/tv/bullet</a></li>
+      <li><a href="https://lichess.org/@/freefal">https://lichess.org/@/freefal</a></li>
+      <li><a href="https://lichess.org/@/freefal/perf/bullet">https://lichess.org/@/freefal/perf/bullet</a></li>
       <li>Create your own challenge to test it</li>
     </ul>
   </body>

--- a/deepLinkTest.html
+++ b/deepLinkTest.html
@@ -21,6 +21,7 @@
       <li><a href="https://lichess.org/analysis">https://lichess.org/analysis</a></li>
       <li><a href="https://lichess.org/analysis/1k6/1r6/2K5/Q7/8/8/8/8_w_-_-">https://lichess.org/analysis/1k6/1r6/2K5/Q7/8/8/8/8_w_-_-</a></li>
       <li><a href="https://lichess.org/editor">https://lichess.org/editor</a></li>
+      <li><a href="https://lichess.org/editor/1k6/1r6/2K5/Q7/8/8/8/8_w_-_-">https://lichess.org/editor/1k6/1r6/2K5/Q7/8/8/8/8_w_-_-</a></li>
       <li><a href="https://lichess.org/inbox">https://lichess.org/inbox</a></li>
       <li><a href="https://lichess.org/inbox/new">https://lichess.org/inbox/new</a></li>
       <li><a href="https://lichess.org/player">https://lichess.org/player</a></li>

--- a/deepLinkTest.html
+++ b/deepLinkTest.html
@@ -19,6 +19,7 @@
     <h1>lichess deep links using normal "https://" scheme</h1>
     <ul>
       <li><a href="https://lichess.org/analysis">https://lichess.org/analysis</a></li>
+      <li><a href="https://lichess.org/analysis/1k6/1r6/2K5/Q7/8/8/8/8_w_-_-">https://lichess.org/analysis/1k6/1r6/2K5/Q7/8/8/8/8_w_-_-</a></li>
       <li><a href="https://lichess.org/editor">https://lichess.org/editor</a></li>
       <li><a href="https://lichess.org/inbox">https://lichess.org/inbox</a></li>
       <li><a href="https://lichess.org/inbox/new">https://lichess.org/inbox/new</a></li>

--- a/src/deepLinks.ts
+++ b/src/deepLinks.ts
@@ -14,6 +14,7 @@ export default {
     universalLinks.subscribe('analysisPosition', handleAnalysisPosition)
     universalLinks.subscribe('challenge', (eventData: UniversalLinks.EventData) => router.set('/challenge/' + eventData.path.split('/').pop()))
     universalLinks.subscribe('editor', () => router.set('/editor'))
+    universalLinks.subscribe('editorPosition', handleEditorPosition)
     universalLinks.subscribe('inbox', () => router.set('/inbox'))
     universalLinks.subscribe('inboxNew', () => router.set('/inbox/new'))
     universalLinks.subscribe('players', () => router.set('/players'))
@@ -57,6 +58,13 @@ function handleAnalysisPosition (eventData: UniversalLinks.EventData) {
   let pathSuffix = eventData.path.replace('/analysis', '')
   pathSuffix = cleanFenUri(pathSuffix)
   router.set(`/analyse/fen/${encodeURIComponent(pathSuffix)}`)
+}
+
+// handle links like https://lichess.org/editor/1k6/1r6/2K5/Q7/8/8/8/8_w_-_-
+function handleEditorPosition (eventData: UniversalLinks.EventData) {
+  let pathSuffix = eventData.path.replace('/editor', '')
+  pathSuffix = cleanFenUri(pathSuffix)
+  router.set(`/editor/${encodeURIComponent(pathSuffix)}`)
 }
 
 function handleTrainingProblem (eventData: UniversalLinks.EventData) {


### PR DESCRIPTION
Opening a link like `lichess.org/analysis/1k6/1r6/2K5/Q7/8/8/8/8_w_-_-` or `lichess.org/editor/1k6/1r6/2K5/Q7/8/8/8/8_w_-_-` in the app will open the lichess.org web page in the in-app browser.
This PR enables such links to open the mobile app pages instead.