### PR TITLE
Load opening explorer info on leading edge

### DIFF
--- a/src/ui/analyse/explorer/ExplorerCtrl.ts
+++ b/src/ui/analyse/explorer/ExplorerCtrl.ts
@@ -63,7 +63,7 @@ export default function ExplorerCtrl(
       redraw()
     })
     .catch(handleFetchError)
-  }, 1000)
+  }, 1000, { leading: true, trailing: true })
 
   const fetchTablebase = debounce((fen: string): Promise<void> => {
     return tablebaseXhr(effectiveVariant, fen)
@@ -76,7 +76,7 @@ export default function ExplorerCtrl(
       redraw()
     })
     .catch(handleFetchError)
-  }, 500)
+  }, 500, { leading: true, trailing: true })
 
   function fetch(fen: string) {
     const hasTablebase = ['standard', 'chess960', 'atomic', 'antichess'].includes(effectiveVariant)


### PR DESCRIPTION
Similar to ornicar/lila@30385b6c41a335d521a647eef78801ffd2336fde from https://github.com/ornicar/lila/pull/3797: Loading also on leading edges makes the explorer feel much faster while bursts of requests are still prevented.