### PR TITLE
Highlight current move in ongoing game analysis

### DIFF
--- a/src/styl/analyse.styl
+++ b/src/styl/analyse.styl
@@ -150,8 +150,7 @@ move
   padding: 0.25em 0.17em
   overflow hidden
   white-space nowrap
-  &.current, &.active
-    border-radius 3px
+  border-radius 3px
   &.current
     color #fff
     background rgba(blue, 0.8)
@@ -159,7 +158,9 @@ move
     > index
       color #fff
   &.active
-      background lighten(bgdark, 10%)
+    background lighten(bgdark, 10%)
+  &.currentPlayable
+    border: 1px solid orange
 
 glyph
   font-size 0.85em


### PR DESCRIPTION
The same way it is done on the desktop.

Before:
<img width="357" alt="screenshot 2018-03-21 20 51 15" src="https://user-images.githubusercontent.com/242988/37731149-0c312a78-2d4a-11e8-98d2-6e8fb5fe97f9.png">

After:
<img width="356" alt="screenshot 2018-03-21 20 51 36" src="https://user-images.githubusercontent.com/242988/37731148-0c0afd4e-2d4a-11e8-9a5b-991dd246189d.png">

