### PR TITLE
Make puzzle orientation explicit

### DIFF
--- a/src/ui/training/TrainingCtrl.ts
+++ b/src/ui/training/TrainingCtrl.ts
@@ -191,9 +191,9 @@ export default class TrainingCtrl implements PromotingInterface {
   public goToAnalysis = () => {
     const puzzle = this.data.puzzle
     if (hasNetwork()) {
-      router.set(`/analyse/online/${puzzle.gameId}/${puzzle.color}?ply=${puzzle.initialPly}&curFen=${puzzle.fen}`)
+      router.set(`/analyse/online/${puzzle.gameId}/${puzzle.color}?ply=${puzzle.initialPly}&curFen=${puzzle.fen}&color=${puzzle.color}`)
     } else {
-      router.set(`/analyse/variant/standard/fen/${encodeURIComponent(this.initialNode.fen)}`)
+      router.set(`/analyse/variant/standard/fen/${encodeURIComponent(this.initialNode.fen)}?color=${puzzle.color}`)
     }
   }
 


### PR DESCRIPTION
Without this, offline puzzles were always shown from white's perspective when moving to the analysis board.