### PR TITLE
Change the bookmark icon to change locally in round view

### DIFF
--- a/src/lichess/interfaces/game.ts
+++ b/src/lichess/interfaces/game.ts
@@ -16,7 +16,7 @@ export interface GameData {
   userTV?: string
   tv?: string
   readonly pref?: any
-  readonly bookmarked?: boolean
+  bookmarked?: boolean
   readonly takebackable?: boolean
 }
 

--- a/src/ui/shared/round/OnlineRound.ts
+++ b/src/ui/shared/round/OnlineRound.ts
@@ -3,7 +3,7 @@ import Chessground from '../../../chessground/Chessground'
 import * as cg from '../../../chessground/interfaces'
 import redraw from '../../../utils/redraw'
 import { saveOfflineGameData, removeOfflineGameData } from '../../../utils/offlineGames'
-import { hasNetwork, boardOrientation } from '../../../utils'
+import { hasNetwork, boardOrientation, handleXhrError } from '../../../utils'
 import session from '../../../session'
 import settings from '../../../settings'
 import socket from '../../../socket'
@@ -557,7 +557,11 @@ export default class OnlineRound implements OnlineRoundInterface {
   }
 
   public toggleBookmark = () => {
-    return toggleGameBookmark(this.data.game.id).then(this.reloadGameData)
+    return toggleGameBookmark(this.data.game.id).then(() => {
+      this.data.bookmarked = !this.data.bookmarked
+      redraw()
+    })
+    .catch(handleXhrError)
   }
 
   public unload() {

--- a/src/ui/shared/round/view/button.tsx
+++ b/src/ui/shared/round/view/button.tsx
@@ -26,7 +26,7 @@ export default {
   },
   bookmark: function(ctrl: OnlineRound) {
     return session.isConnected() ? h('button', {
-      key: 'shareGameLink',
+      key: 'bookmarkLink',
       oncreate: helper.ontap(ctrl.toggleBookmark),
       'data-icon': ctrl.data.bookmarked ? 't' : 's'
     }, [i18n('bookmarkThisGame')]) : null


### PR DESCRIPTION
After successfully toggling the bookmark in the server, there is no need for a separate request to update the gamedata just to toggle the UI. This is the way it is already done in the search and game list views.

Also, there seems to be some problem in the server - it takes some time for it to start returning "bookmarked = true"  in the gameData.  This causes the UI to not toggle at all, this PR works around this issue.