### PR TITLE
Make hardware keys control media by default

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -82,6 +82,7 @@
     <preference name="xwalkMode" value="embedded" />
     <preference name="xwalkMultipleApk" value="true" />
     <preference name="AndroidLaunchMode" value="singleInstance" />
+    <preference name="DefaultVolumeStream" value="media" />
     <universal-links>
         <host name="lichess.org" scheme="https">
             <path event="analysis" url="/analysis" />


### PR DESCRIPTION
A pain point for me and (I suspect) others with the app is that sometimes the piece movement volume is too loud or too soft, but using the volume keys defaults to adjusting the ring volume. This PR changes the default volume controlled by the hardware keys to instead be the media volume.