### PR TITLE
Upgrade webview to fix build errors

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -109,7 +109,7 @@
     <plugin name="com.rjfun.cordova.plugin.lowlatencyaudio" spec="https://github.com/veloce/cordova-plugin-nativeaudio.git#old_interface" />
     <plugin name="cordova-plugin-app-event" spec="git+https://github.com/katzer/cordova-plugin-app-event.git#1.2.1" />
     <plugin name="cordova-plugin-appversion" spec="1.0.0" />
-    <plugin name="cordova-plugin-crosswalk-webview" spec="2.3.0">
+    <plugin name="cordova-plugin-crosswalk-webview" spec="2.4.0">
         <variable name="XWALK_MODE" value="embedded" />
         <variable name="XWALK_MULTIPLEAPK" value="true" />
     </plugin>

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "cordova-ios": "4.5.4",
         "cordova-plugin-app-event": "git+https://github.com/katzer/cordova-plugin-app-event.git#1.2.1",
         "cordova-plugin-appversion": "1.0.0",
-        "cordova-plugin-crosswalk-webview": "2.3.0",
+        "cordova-plugin-crosswalk-webview": "2.4.0",
         "cordova-plugin-device": "1.1.4",
         "cordova-plugin-dialogs": "1.3.1",
         "cordova-plugin-file-transfer": "1.6.1",


### PR DESCRIPTION
Upgrade `cordova-plugin-crosswalk-webview` package to `2.3.0` to `2.4.0` in order to take advantage of this fix for Cordova 7.0 (https://github.com/crosswalk-project/cordova-plugin-crosswalk-webview/commit/e58176139cab79bfc2351436acd35664348fff6c)