### PR TITLE
Fix En Passant in Atomic

### DIFF
--- a/src/ui/shared/round/OnlineRound.ts
+++ b/src/ui/shared/round/OnlineRound.ts
@@ -414,11 +414,6 @@ export default class OnlineRound implements OnlineRoundInterface {
       if (o.enpassant) {
         const p = o.enpassant
         enpassantPieces[p.key] = null
-        if (d.game.variant.key === 'atomic') {
-          atomic.enpassant(this.chessground, p.key, p.color)
-        } else {
-          sound.capture()
-        }
       }
 
       const castlePieces: {[index: string]: Piece | null} = {}
@@ -464,6 +459,15 @@ export default class OnlineRound implements OnlineRoundInterface {
 
       if (o.promotion) {
         ground.promote(this.chessground, o.promotion.key, o.promotion.pieceClass)
+      }
+
+      if (o.enpassant) {
+        const p = o.enpassant
+        if (d.game.variant.key === 'atomic') {
+          atomic.enpassant(this.chessground, p.key, p.color)
+        } else {
+          sound.capture()
+        }
       }
     }
 


### PR DESCRIPTION
Previously, chessground was not updated for the en passant move before trying to explode the pieces (but, per the rules of atomic, not pawns) around the capturing pawn. This meant that `chessgroundCtrl.state.pieces[k]` in this line (https://github.com/veloce/lichobile/blob/master/src/ui/shared/round/atomic.ts#L14) always returned false because the pawn hadn't yet reached its destination square.

This PR simply moves the atomic explosion code so that it is processed after the move is processed. I've tested this and it fixes the issue.

Closes: https://github.com/veloce/lichobile/issues/884