### PR TITLE
Let login modal handle HTTP 400 and 401

### DIFF
--- a/src/ui/loginModal.ts
+++ b/src/ui/loginModal.ts
@@ -118,7 +118,7 @@ function submit(form: HTMLFormElement) {
     if (err.body.ipban) {
       close()
     } else {
-      if (err.status !== 401) handleXhrError(err)
+      if (err.status !== 400 && err.status !== 401) handleXhrError(err)
       else {
         if (err.body.global) {
           formError = err.body.global[0]


### PR DESCRIPTION
This fixes error handling in the login modal (and specifically 2fa) after ornicar/lila@a5053e2d41e71764a04338cbd8abd3a518f0089b changed the status code from 401 to 400. I'll also submit a PR that partially reverts this in lila (at least mid-term), but I think it's good to also be flexible in lichobile.