### PR TITLE
Make perfRatings with no seperate pages unclickable

### DIFF
--- a/src/ui/user/userView.tsx
+++ b/src/ui/user/userView.tsx
@@ -167,14 +167,16 @@ function variantPerfAvailable(key: PerfKey, perf: Perf) {
 function renderPerf(key: PerfKey, name: string, perf: Perf, user: ProfileUser) {
 
   const avail = variantPerfAvailable(key, perf)
-
-  return h('div', {
+  
+  const props = {
     className: 'profilePerf' + (avail ? ' nav' : ''),
     'data-icon': gameIcon(key),
-    oncreate: helper.ontapY(() => {
-      if (hasNetwork() && avail) router.set(`/@/${user.id}/${key}/perf`)
-    })
-  }, [
+    oncreate: avail ? helper.ontapY(() => {
+      if (hasNetwork()) router.set(`/@/${user.id}/${key}/perf`)
+    }) : null
+  }
+
+  return h('div', props, [
     h('span.name', name),
     h('div.rating', [
       perf.rating,

--- a/src/ui/user/userView.tsx
+++ b/src/ui/user/userView.tsx
@@ -167,7 +167,7 @@ function variantPerfAvailable(key: PerfKey, perf: Perf) {
 function renderPerf(key: PerfKey, name: string, perf: Perf, user: ProfileUser) {
 
   const avail = variantPerfAvailable(key, perf)
-  
+
   const props = {
     className: 'profilePerf' + (avail ? ' nav' : ''),
     'data-icon': gameIcon(key),


### PR DESCRIPTION
If `avail` is false don't make the rating clickable.

Also factored out to the `div` properties into `prop` to make the code slightly easier to read.

Closes https://github.com/veloce/lichobile/issues/952