### PR TITLE
Fix off-by-one error when first ply in 'treeParts' is not 0

### DIFF
--- a/src/ui/analyse/charts/acpl.ts
+++ b/src/ui/analyse/charts/acpl.ts
@@ -35,10 +35,11 @@ export default function drawAcplChart(element: SVGElement, aData: AnalyseData, c
     .text(name)
   }
 
+  const firstPly = aData.treeParts[0].ply || 0
   function setCurrentPly(ply: number | null) {
     g.selectAll('.dot').remove()
     if (ply !== null) {
-      const xply = ply - 1
+      const xply = ply - 1 - firstPly
       const p = graphData[xply]
       if (p) {
         g.append('circle')


### PR DESCRIPTION
This does not address the fact that `xply` can be negative and when used to index into `graphData` results in `undefined`

Closes https://github.com/veloce/lichobile/issues/935