### PR TITLE
issue #876: workaround - new button to resync puzzles

### DIFF
--- a/src/ui/training/TrainingCtrl.ts
+++ b/src/ui/training/TrainingCtrl.ts
@@ -121,6 +121,26 @@ export default class TrainingCtrl implements PromotingInterface {
     return true
   }
 
+  public resync = () => {
+    const user = session.get()
+    if (user) {
+      const onSuccess = (cfg: PuzzleData) => {
+        this.vm.loading = false
+        this.init(cfg)
+        redraw()
+      }
+      this.database.clean(user.id).then(() => {
+        syncAndLoadNewPuzzle(this.database, user)
+        .then(onSuccess)
+        .catch(error => {
+          this.vm.loading = false
+          redraw()
+          puzzleLoadFailure(error)
+        })
+      })
+    }
+  }
+
   public rewind = () => {
     if (this.canGoBackward()) {
       this.userJump(treePath.init(this.path), false)

--- a/src/ui/training/database.ts
+++ b/src/ui/training/database.ts
@@ -4,6 +4,7 @@ import { PuzzleOutcome, PuzzleData, UserData } from '../../lichess/interfaces/tr
 const db = {
   fetch,
   save,
+  clean,
 }
 
 export default db
@@ -34,4 +35,8 @@ function fetch(userId: UserId): Promise<UserOfflineData | null> {
 
 function save(userId: UserId, userData: UserOfflineData): Promise<UserOfflineData> {
   return asyncStorage.setItem(`offlinePuzzles.${userId}`, userData)
+}
+
+function clean(userId: UserId) {
+  return asyncStorage.removeItem(`offlinePuzzles.${userId}`)
 }

--- a/src/ui/training/trainingView.ts
+++ b/src/ui/training/trainingView.ts
@@ -69,6 +69,10 @@ function renderActionsBar(ctrl: TrainingCtrl) {
       oncreate: helper.ontap(ctrl.goToAnalysis, () => window.plugins.toast.show(i18n('analysis'), 'short', 'bottom')),
       disabled: ctrl.vm.mode !== 'view'
     }),
+    h('button.action_bar_button.training_action.fa.fa-refresh', {
+      key: 'puzzleRefresh',
+      oncreate: helper.ontap(ctrl.resync)
+    }),
     h('button.action_bar_button.training_action.fa.fa-backward', {
       oncreate: helper.ontap(ctrl.rewind, undefined, ctrl.rewind),
       key: 'historyPrev',


### PR DESCRIPTION
Related issues https://github.com/veloce/lichobile/issues/876 and https://github.com/ornicar/lila/issues/4409

The synchronization  problem between the puzzles between the website and the app is that the app maintains an offline cache of puzzles. 
The solution I propose is not the most elegant, but after so many months of suffering the incidence, I think it's worth it until we get something better. It tries to add a button to invalidate the local cache and re-request a new batch of puzzles to the server.

You can see the new "resync" button to the right of the analysis button:

![issue#876-workaround](https://user-images.githubusercontent.com/1201504/54306862-a1192200-45ca-11e9-9a69-89e322de09ca.png)
