### PR TITLE
Fix analysis scrolling

### DIFF
--- a/src/styl/analyse.styl
+++ b/src/styl/analyse.styl
@@ -76,7 +76,7 @@
   display flex
   flex-flow column nowrap
   min-width 0 // fix width bug on landscape
-  min-height 0 // fix chrome 72 bug
+  min-height 0 // fix chrome bug
   @media only screen and (orientation: landscape)
     margin-top 0
 
@@ -88,7 +88,7 @@
 .analyse-tabsContent
   background lighten(bgdark, 5%)
   flex 1 1 auto
-  min-height 0 // fix chrome 72 bug
+  min-height 0 // fix chrome bug
   > .tab-content
     > div
       flex-grow 1
@@ -123,7 +123,7 @@
 .analyse-replayWrapper
   display: flex
   flex-flow column nowrap
-  min-height 0 // fix chrome 72 bug
+  min-height 0 // fix chrome bug
   > .native_scroller
     // flex height
     height initial

--- a/src/styl/board-content.styl
+++ b/src/styl/board-content.styl
@@ -2,7 +2,7 @@
   flex 1 1 auto
   display flex
   flex-flow column nowrap
-  min-height 0 // fix chrome 72 bug
+  min-height 0 // fix chrome bug
   @media only screen and (orientation: landscape)
     display flex
     flex-flow row nowrap


### PR DESCRIPTION
Reapply patch that @veloce originally wrote to fix the analysis scrolling bug, which has reappeared in Chrome 74.