### PR TITLE
Upgrade gulp-preprocess to 3.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6151,22 +6151,14 @@
             }
         },
         "gulp-preprocess": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/gulp-preprocess/-/gulp-preprocess-2.0.0.tgz",
-            "integrity": "sha1-Bnv2pOG3A9e0XtIEfOfofVl00kE=",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/gulp-preprocess/-/gulp-preprocess-3.0.2.tgz",
+            "integrity": "sha512-RsPVAlZPMo8HQwtYdu9g9iwD/IiEOfXz30fASBhiYoUL1B+Hqpw3NnCB4u2SD6foIRMkir7uwLFzjaLuo3jE5A==",
             "dev": true,
             "requires": {
-                "lodash": "3.10.x",
-                "map-stream": "0.1.x",
+                "lodash": "^4.17.11",
+                "map-stream": "^0.1.x",
                 "preprocess": "^3.0.0"
-            },
-            "dependencies": {
-                "lodash": {
-                    "version": "3.10.1",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                    "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-                    "dev": true
-                }
             }
         },
         "gulp-rename": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "fancy-log": "1.3.3",
         "gulp": "4.0.2",
         "gulp-autoprefixer": "6.1.0",
-        "gulp-preprocess": "2.0.0",
+        "gulp-preprocess": "3.0.2",
         "gulp-rename": "1.2.2",
         "gulp-sourcemaps": "2.4.0",
         "gulp-stylus": "2.7.0",


### PR DESCRIPTION
Discovered a vulnerability with `npm audit` in Gulp v2.0.0. Upgraded to 3.0.2 and tested via `npm run build`, `npm run build-stage`, and `npm watch`.