### PR TITLE
Upgrade Stockfish plugin to fix build issues

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -126,7 +126,7 @@
     <plugin name="cordova-plugin-globalization" spec="1.11.0" />
     <plugin name="cordova-plugin-crosswalk-data-migration" spec="git+https://github.com/veloce/cordova-plugin-crosswalk-data-migration.git#225408d" />
     <plugin name="ionic-plugin-keyboard" spec="2.2.1" />
-    <plugin name="cordova-plugin-stockfish" spec="https://github.com/veloce/cordova-plugin-stockfish.git#v1.8.0" />
+    <plugin name="cordova-plugin-stockfish" spec="https://github.com/veloce/cordova-plugin-stockfish.git#7cc6722" />
     <plugin name="cordova-plugin-x-toast" spec="2.7.2" />
     <plugin name="cordova-plugin-file-transfer" spec="1.7.1" />
     <plugin name="onesignal-cordova-plugin" spec="2.4.7" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -3858,8 +3858,8 @@
             "integrity": "sha1-/B+9wNjXAzp+jh8ff/FnrJvU+vY="
         },
         "cordova-plugin-stockfish": {
-            "version": "git+https://github.com/veloce/cordova-plugin-stockfish.git#9ef355d49ca6820191c4613ea9e914dcc97b123d",
-            "from": "git+https://github.com/veloce/cordova-plugin-stockfish.git#v1.8.0"
+            "version": "git+https://github.com/veloce/cordova-plugin-stockfish.git#7cc6722888bf482584205ca753c288826786c73b",
+            "from": "git+https://github.com/veloce/cordova-plugin-stockfish.git#7cc6722"
         },
         "cordova-plugin-vibration": {
             "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "cordova-plugin-network-information": "2.0.1",
         "cordova-plugin-splashscreen": "5.0.2",
         "cordova-plugin-statusbar": "2.4.2",
-        "cordova-plugin-stockfish": "git+https://github.com/veloce/cordova-plugin-stockfish.git#v1.8.0",
+        "cordova-plugin-stockfish": "git+https://github.com/veloce/cordova-plugin-stockfish.git#7cc6722",
         "cordova-plugin-vibration": "3.1.0",
         "cordova-plugin-whitelist": "1.3.3",
         "cordova-plugin-x-socialsharing": "5.1.3",


### PR DESCRIPTION
Upgraded `cordova-plugin-stockfish` to the most recent commit (https://github.com/veloce/cordova-plugin-stockfish/commit/7cc6722888bf482584205ca753c288826786c73b) to fix the Android NDK build issues. See https://github.com/veloce/cordova-plugin-stockfish/pull/14.