### PR TITLE
Add `moretime` field to settings update request sent to server

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -160,7 +160,8 @@ function savePreferences(): Promise<string> {
     'autoQueen',
     'autoThreefold',
     'submitMove',
-    'confirmResign'
+    'confirmResign',
+    'moretime'
   ]), numValue), (_, k) => 'behavior.' + k) as StringMap
   const rest = mapValues(pick(prefs, [
     'clockTenths',


### PR DESCRIPTION
Fix 'bad request' error when updating game behavior settings by submitting 'moretime' field.

Resolves https://github.com/veloce/lichobile/issues/1020