### PR TITLE
Fix display of Stockfish analysis with multiple lines.

### DIFF
--- a/src/ui/analyse/ceval/StockfishEngine.ts
+++ b/src/ui/analyse/ceval/StockfishEngine.ts
@@ -15,7 +15,6 @@ export default function StockfishEngine(variant: VariantKey): IEngine {
   let readyPromise: Promise<void> = Promise.resolve()
 
   let curEval: Tree.ClientEval | null = null
-  let expectedPvs = 1
 
   // after a 'go' command, stockfish will be continue to emit until the 'bestmove'
   // message, reached by depth or after a 'stop' command
@@ -91,6 +90,7 @@ export default function StockfishEngine(variant: VariantKey): IEngine {
       })
 
       return setOption('Threads', work.cores)
+      .then(() => curEval = null)
       .then(() => setOption('MultiPV', work.multiPv))
       .then(() => send(['position', 'fen', work.initialFen, 'moves'].concat(work.moves).join(' ')))
       .then(() => send('go depth ' + work.maxDepth))
@@ -128,9 +128,6 @@ export default function StockfishEngine(variant: VariantKey): IEngine {
     // Sometimes we get #0. Let's just skip it.
     if (isMate && !ev) return
 
-    // Track max pv index to determine when pv prints are done.
-    if (expectedPvs < multiPv) expectedPvs = multiPv
-
     let pivot = work.threatMode ? 0 : 1
     if (work.ply % 2 === pivot) ev = -ev
 
@@ -147,7 +144,7 @@ export default function StockfishEngine(variant: VariantKey): IEngine {
       depth
     }
 
-    if (multiPv === 1) {
+    if (curEval == null) {
       curEval = {
         fen: work.currentFen,
         maxDepth: work.maxDepth,
@@ -159,14 +156,20 @@ export default function StockfishEngine(variant: VariantKey): IEngine {
         pvs: [pvData],
         millis: elapsedMs
       }
-    } else if (curEval) {
-      curEval.pvs.push(pvData)
-      curEval.depth = Math.min(curEval.depth, depth)
+    } else {
+      if (multiPv === 1) {
+        curEval.depth = depth
+      }
+
+      const multiPvIdx = multiPv - 1
+      if (curEval.pvs.length > multiPvIdx) {
+        curEval.pvs[multiPvIdx] = pvData
+      } else {
+        curEval.pvs.push(pvData)
+      }
     }
 
-    if (multiPv === expectedPvs && curEval) {
-      work.emit(curEval)
-    }
+    work.emit(curEval)
   }
 
 


### PR DESCRIPTION
Fix the display of Stockfish's analysis when multiple analysis lines
are used (MultiPV > 1).  There are two situations where this is broken:

1. The position has fewer legal moves than the requested MultiPV.
(Stockfish only emits one line for each legal move, even if the MultiPV
option is higher than that.)
2. The user does some analysis with a high MultiPV, and then sets it to
a lower value.  (We have no mechanism to reset expectedPvs to a lower
value, it can only ever increase.)

In either case, we will not receive a multipv value equal to
expectedPvs.  This means that we never emit the analysis received from
Stockfish inside StockfishEngine.processOutput.  This manifests in the
UI as an hourglass in the Stockfish section of the Analysis board, and
the hourglass never goes away, even when Stockfish has finished its
analysis of the position (i.e. issued its "bestmove" line).

Repro: Analysis Board > Settings > Set Analysis lines to 5 / 5 > Switch
to Stockfish tab (small cogs icon).  Move f4.  Wait for analysis lines
to appear.  Settings > Set Analysis lines to 1 / 5.  Move e5.  Observe
hourglass appears in Stockfish tab and never disappears (situation 2 above).
Settings > Set Analysis lines to 5 / 5.  Move Nf3, Qh4.  Observe
hourglass again never disappears (situation 1 above).

Fix this by removing StockfishEngine.expectedPvs entirely.  Instead,
aggregate the analysis lines inside curEval, and emit curEval as work
for each line that we process. This means that we update the UI for
each analysis line, rather than waiting for N lines before updating.
As part of this, clear curEval when starting a new search (inside
StockfishEngine.search).