### PR TITLE
Conform naming of 'Quick Pairing' and utilize new translations

### DIFF
--- a/src/ui/newGameForm.ts
+++ b/src/ui/newGameForm.ts
@@ -107,7 +107,7 @@ function renderContent() {
   return h('div', [
     h('div.newGame-preset_switch', [
       h('div.nice-radio', formWidgets.renderRadio(
-        'Quick game',
+        i18n('quickPairing'),
         'preset',
         'quick',
         tabPreset === 'quick',


### PR DESCRIPTION
I was not able to test this because I couldn't get `npm run watch` to run on the new capacitor branch without errors, but this seems like a pretty harmless edit that addresses https://github.com/veloce/lichobile/issues/1053