### PR TITLE
Make player names in message thread clickable

### DIFF
--- a/src/styl/inbox.styl
+++ b/src/styl/inbox.styl
@@ -95,8 +95,10 @@ table.threadList
       >.arrow
         vertical-align middle
         line-height 1
-      >.user
-        display inline
+      span
+        >.user
+          display inline
+
     > .text
       overflow hidden
       word-break break-word

--- a/src/ui/inbox/thread/threadView.tsx
+++ b/src/ui/inbox/thread/threadView.tsx
@@ -5,6 +5,7 @@ import i18n from '../../../i18n'
 import { linkify } from '../../../utils/html'
 import redraw from '../../../utils/redraw'
 import { Post } from '../interfaces'
+import router from '../../../router'
 
 import { IThreadCtrl } from './threadCtrl'
 
@@ -47,9 +48,13 @@ function renderPost(post: Post, index: number, posts: Array<Post>) {
   return (
     <div className={postClass} key={post.createdAt}>
       <div className="infos">
-        {userStatus(post.sender)}
+        <span id="sender" oncreate={helper.ontapY(() => router.set('/@/' + post.sender.id))}>
+          {userStatus(post.sender)}
+        </span>
         <span className="arrow" data-icon="H" />
-        {userStatus(post.receiver)}
+        <span id="receiver" oncreate={helper.ontapY(() => router.set('/@/' + post.receiver.id))}>
+          {userStatus(post.receiver)}
+        </span>
         &nbsp;–&nbsp;
         {postDateFormat(post.createdAt)}
       </div>

--- a/src/ui/user/index.ts
+++ b/src/ui/user/index.ts
@@ -33,7 +33,7 @@ const UserScreen: Mithril.Component<Attrs, State> = {
 
     if (user) {
       return layout.free(
-        view.header(user, this.ctrl),
+        view.header(user),
         view.profile(user, this.ctrl)
       )
     } else {

--- a/src/ui/user/userView.tsx
+++ b/src/ui/user/userView.tsx
@@ -13,10 +13,10 @@ import * as helper from '../helper'
 import session from '../../session'
 import { IUserCtrl, ProfileUser, isSessionUser, isFullUser } from './UserCtrl'
 
-export function header(user: ProfileUser, ctrl: IUserCtrl) {
+export function header(user: ProfileUser) {
   const title = userTitle(user.online!!, user.patron!!, user.username, user.title)
 
-  const backButton = !ctrl.isMe() ? renderBackbutton(title) : null
+  const backButton = renderBackbutton(title)
   return dropShadowHeader(backButton ? null : title, backButton)
 }
 


### PR DESCRIPTION
I also discovered that the back button isn't shown if the player is the user himself, but this doesn't make sense to me. Why not still let the user navigate backward to where he came from even if he's looking up himself? I've removed that test and now the back button is always shown. I can revert this change if there's a reason for this behavior.

Closes https://github.com/veloce/lichobile/issues/1051