### PR TITLE
Correct the horde alert

### DIFF
--- a/src/lichess/variant.ts
+++ b/src/lichess/variant.ts
@@ -76,7 +76,7 @@ const variantMap: {[key: string]: DocVariant} = {
     tinyName: 'Horde',
     id: 8,
     link: 'https://lichess.org/variant/horde',
-    alert: 'This is a horde chess game!\n\nWhite must take all black pawns to win. Black must checkmate white king.',
+    alert: 'This is a horde chess game!\n\nBlack must take all white pawns to win. White must checkmate black king.',
     title: 'Destroy the horde to win!',
     initialFen: 'rnbqkbnr/pppppppp/8/1PP2PP1/PPPPPPPP/PPPPPPPP/PPPPPPPP/PPPPPPPP w kq - 0 1'
   },


### PR DESCRIPTION
 The first-time alert for the Horde variant had white's and black's variant goals reversed.

![image](https://user-images.githubusercontent.com/6662991/69902706-51e07080-1356-11ea-9632-7e376c689bcf.png)
