### PR TITLE
fixed #1060

### DIFF
--- a/src/ui/shared/round/view/roundView.tsx
+++ b/src/ui/shared/round/view/roundView.tsx
@@ -548,8 +548,8 @@ function renderGamePopup(ctrl: OnlineRound) {
 }
 
 function renderGameActionsBar(ctrl: OnlineRound) {
-  const answerRequired = ctrl.data.opponent.proposingTakeback ||
-    ctrl.data.opponent.offeringDraw ||
+  const answerRequired = ((ctrl.data.opponent.proposingTakeback ||
+    ctrl.data.opponent.offeringDraw) && !gameStatusApi.finished(ctrl.data)) ||
     gameApi.forceResignable(ctrl.data) ||
     ctrl.data.opponent.offeringRematch
 


### PR DESCRIPTION
answerRequired should be false if the reason for answerRequired is a draw offer or takeback request and the game is already over.

This is just a surface level fix for issue #1060 , I thought about setting proposingTakeback and offeringDraw to false when the game ends, but I don't know how to go about that and what possible side-effects could be caused by that.