### PR TITLE
Change CSS to accomodate new 3x4 grid (vs. old 3x3 grid)

### DIFF
--- a/src/styl/new-game.styl
+++ b/src/styl/new-game.styl
@@ -45,7 +45,6 @@
   flex-grow 1
   display: grid
   grid-template-columns: repeat(3, 1fr)
-  grid-template-rows: repeat(3, 1fr)
   grid-gap: 0.8em
   padding: 0.8em
   &.loading

--- a/src/styl/new-game.styl
+++ b/src/styl/new-game.styl
@@ -45,8 +45,8 @@
   flex-grow 1
   display: grid
   grid-template-columns: repeat(3, 1fr)
-  grid-gap: 0.8em
-  padding: 0.8em
+  grid-gap: 0.4em
+  padding: 0.4em
   &.loading
     display flex
     align-items center

--- a/src/xhr.ts
+++ b/src/xhr.ts
@@ -112,6 +112,7 @@ export let cachedPools: ReadonlyArray<Pool> = []
 export function lobby(feedback?: boolean): Promise<LobbyData> {
   return fetchJSON('/', undefined, feedback)
   .then((d: LobbyData) => {
+    console.log(d)
     if (d.lobby.pools !== undefined) cachedPools = d.lobby.pools
     return d
   })

--- a/src/xhr.ts
+++ b/src/xhr.ts
@@ -112,7 +112,6 @@ export let cachedPools: ReadonlyArray<Pool> = []
 export function lobby(feedback?: boolean): Promise<LobbyData> {
   return fetchJSON('/', undefined, feedback)
   .then((d: LobbyData) => {
-    console.log(d)
     if (d.lobby.pools !== undefined) cachedPools = d.lobby.pools
     return d
   })


### PR DESCRIPTION
Issue: The bottom row is shorter for the new 3x4 grid

![old](https://user-images.githubusercontent.com/954742/78834323-6a276280-79bc-11ea-8132-528d8cd646cd.png)

Solution: Just specify that the grid has three columns, but don't specify the number of row. This gracefully handles both the new 3x4 grid

![new (4 rows)](https://user-images.githubusercontent.com/954742/78834341-701d4380-79bc-11ea-9acf-823552d3781a.png)

...and the old 3x3 grid.
![new (3 rows)](https://user-images.githubusercontent.com/954742/78834344-727f9d80-79bc-11ea-93f6-e88b4ac621b7.png)

My dev machine downloaded the new 3x4 grid and presumably people's phones will do the same as their caches expire (I think) so would be good to make this CSS change now so the UI can gracefully handle the switchover from 3x3 to 3x4.


