### PR TITLE
Fix for premature flagging for OTB clock.

### DIFF
--- a/src/ui/otb/otbView.tsx
+++ b/src/ui/otb/otbView.tsx
@@ -80,7 +80,7 @@ function renderGameActionsBar(ctrl: OtbRound) {
       />
       <button className="action_bar_button fa fa-plus-circle"
         oncreate={helper.ontap(
-          ctrl.newGameMenu.open,
+          () => { ctrl.saveClock(); ctrl.newGameMenu.open() },
           () => Plugins.LiToast.show({ text: i18n('createAGame'), duration: 'short', position: 'bottom' })
         )}
       />


### PR DESCRIPTION
This PR should fix the issue reported in #1214. It does so by stopping the OTB clock from ticking when the user taps and opens the 'newGameMenu'. 