### PR TITLE
Fixes the non-responsive behavior when switching back to 'None' clock…

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -202,7 +202,7 @@ export default {
     blackPlayer: prop('otb.blackPlayer', 'Black'),
     clockType: prop<ClockType | 'none'>('otb.clockType', 'none'),
     availableClocks: [
-      ['none', 'None']
+      ['None', 'none']
     ].concat(availableClocks)
   },
 


### PR DESCRIPTION
… type in otb. Issue #1255.