### PR TITLE
Fix a typo in Hebrew localisation

### DIFF
--- a/www/i18n/he-IL.js
+++ b/www/i18n/he-IL.js
@@ -312,7 +312,7 @@ export default {
   "berserkRate": "מתוכם ברזרק",
   "performance": "דירוג הביצוע",
   "tournamentComplete": "הטורניר הושלם",
-  "movesPlayed": "מהלים ששוחקו",
+  "movesPlayed": "מהלכים ששוחקו",
   "whiteWins": "לבן מנצח",
   "blackWins": "שחור מנצח",
   "draws": "תוצאות תיקו",


### PR DESCRIPTION
The word for moves played is מהלכים, not מהלים.