### PR TITLE
Fill in missing dates in ratings graph

### DIFF
--- a/src/ui/user/perfStats/variantPerfView.tsx
+++ b/src/ui/user/perfStats/variantPerfView.tsx
@@ -31,9 +31,9 @@ export function renderBody(ctrl: State) {
   const mins = Math.floor(data.stat.count.seconds / 60) - days * 24 * 60 - hours * 60
   const now = Date.now()
   const yearsAgo = now - (ONE_YEAR * 3)
-  const graphData = data.graph
+  const graphData = smoothGraphData(data.graph
     .map(normalizeGraphData)
-    .filter(d => d.date.getTime() > yearsAgo)
+    .filter(d => d.date.getTime() > yearsAgo))
 
   const { vw } = helper.viewportDim()
 
@@ -258,6 +258,23 @@ function drawChart(graphData: GraphData, el: SVGElement) {
 
 function normalizeGraphData(i: GraphPoint): DateRating {
   return { date: new Date(i[0], i[1], i[2]), rating: i[3] }
+}
+
+function smoothGraphData(graphData: GraphData): GraphData {
+  const copy = graphData.slice()
+  const reversed = graphData.slice().reverse()
+  const startDate = copy[0].date
+  const endDate = copy[copy.length-1].date
+
+  for (var allDates: Array<Date> = [], dt=new Date(startDate); dt<=endDate; dt.setDate(dt.getDate()+1)) {
+        allDates.push(new Date(dt))
+  }
+  const result: Array<DateRating> = []
+  allDates.forEach((dt) => {
+    const match = reversed.find((rev) => rev.date <= dt)
+    match && result.push({date: dt, rating: match.rating})
+  })
+  return result
 }
 
 const formatWeek = timeFormat('%b %d')

--- a/src/ui/user/perfStats/variantPerfView.tsx
+++ b/src/ui/user/perfStats/variantPerfView.tsx
@@ -264,16 +264,19 @@ function smoothGraphData(graphData: GraphData): GraphData {
   const copy = graphData.slice()
   const reversed = graphData.slice().reverse()
   const startDate = copy[0].date
-  const endDate = copy[copy.length-1].date
+  const endDate = copy[copy.length - 1].date
 
-  for (var allDates: Array<Date> = [], dt=new Date(startDate); dt<=endDate; dt.setDate(dt.getDate()+1)) {
+  const allDates: Array<Date> = []
+  for (let dt = new Date(startDate); dt <= endDate; dt.setDate(dt.getDate() + 1)) {
         allDates.push(new Date(dt))
   }
+
   const result: Array<DateRating> = []
   allDates.forEach((dt) => {
     const match = reversed.find((rev) => rev.date <= dt)
     match && result.push({date: dt, rating: match.rating})
   })
+
   return result
 }
 


### PR DESCRIPTION
Fill in missing dates in the ratings graph with the previous rating. Implemented in lila here: https://github.com/ornicar/lila/pull/6902

In [the original issue](https://github.com/ornicar/lila/issues/6743):

> To add, I'd say that if my rating on January 1 is 2000 and I don't play until May 5, when I drop 50 points to 1950, I would expect the graph to be a straight line at 2000 from January 1 till May 4, and then a one-day steep drop to 1950. As that's what happened: my rating was still 2000 on May 4, and dropped to 1950 on May 5.
> 
> (Right now the plot would draw a straight line from 2000 on January 1 to 1950 on May 5, as if I gradually lost my rating over time. It's incorrect and inelegant.)

Tested in REPL:

```
> example
[
  { date: 2020-05-15T07:00:00.000Z, rating: 1500 },
  { date: 2020-06-10T07:00:00.000Z, rating: 1800 },
  { date: 2020-06-11T07:00:00.000Z, rating: 1900 },
  { date: 2020-06-13T07:00:00.000Z, rating: 2000 }
]
> smoothGraphData(example)
[
  { date: 2020-05-15T07:00:00.000Z, rating: 1500 },
  { date: 2020-05-16T07:00:00.000Z, rating: 1500 },
  { date: 2020-05-17T07:00:00.000Z, rating: 1500 },
  { date: 2020-05-18T07:00:00.000Z, rating: 1500 },
  { date: 2020-05-19T07:00:00.000Z, rating: 1500 },
  { date: 2020-05-20T07:00:00.000Z, rating: 1500 },
  { date: 2020-05-21T07:00:00.000Z, rating: 1500 },
  { date: 2020-05-22T07:00:00.000Z, rating: 1500 },
  { date: 2020-05-23T07:00:00.000Z, rating: 1500 },
  { date: 2020-05-24T07:00:00.000Z, rating: 1500 },
  { date: 2020-05-25T07:00:00.000Z, rating: 1500 },
  { date: 2020-05-26T07:00:00.000Z, rating: 1500 },
  { date: 2020-05-27T07:00:00.000Z, rating: 1500 },
  { date: 2020-05-28T07:00:00.000Z, rating: 1500 },
  { date: 2020-05-29T07:00:00.000Z, rating: 1500 },
  { date: 2020-05-30T07:00:00.000Z, rating: 1500 },
  { date: 2020-05-31T07:00:00.000Z, rating: 1500 },
  { date: 2020-06-01T07:00:00.000Z, rating: 1500 },
  { date: 2020-06-02T07:00:00.000Z, rating: 1500 },
  { date: 2020-06-03T07:00:00.000Z, rating: 1500 },
  { date: 2020-06-04T07:00:00.000Z, rating: 1500 },
  { date: 2020-06-05T07:00:00.000Z, rating: 1500 },
  { date: 2020-06-06T07:00:00.000Z, rating: 1500 },
  { date: 2020-06-07T07:00:00.000Z, rating: 1500 },
  { date: 2020-06-08T07:00:00.000Z, rating: 1500 },
  { date: 2020-06-09T07:00:00.000Z, rating: 1500 },
  { date: 2020-06-10T07:00:00.000Z, rating: 1800 },
  { date: 2020-06-11T07:00:00.000Z, rating: 1900 },
  { date: 2020-06-12T07:00:00.000Z, rating: 1900 },
  { date: 2020-06-13T07:00:00.000Z, rating: 2000 }
]
> 
```