### PR TITLE
Set unzip maxBuffer to 10MB 

### DIFF
--- a/scripts/i18n-update.ts
+++ b/scripts/i18n-update.ts
@@ -7,6 +7,7 @@ const colors = require('colors/safe');
 
 const baseDir = 'tmp/translations';
 const i18nBaseDir = '../www/i18n';
+const unzipMaxBufferSize = 1024 * 1024 * 10; // Set maxbuffer to 10MB to avoid errors when default 1MB used
 
 type StringMap = {
   [i: string]: string | undefined
@@ -24,7 +25,7 @@ function downloadTranslationsTo(zipFile: WriteStream) {
 function unzipTranslations(zipFilePath: string) {
   console.log(colors.blue('Unzipping translations...'));
   return new Promise((resolve, reject) => {
-      exec(`unzip -o ${zipFilePath} -d ${baseDir}`, (err, stdout, stderr) => {
+      exec(`unzip -o ${zipFilePath} -d ${baseDir}`, {maxBuffer: unzipMaxBufferSize}, (err, stdout, stderr) => {
       if (err) {
         return reject('Unzip failed.');
       }


### PR DESCRIPTION
Set maxBuffer to 10MB when executing unzip to avoid errors encountered when default 1MB used

Found a similar issue and fix here: https://github.com/nicojs/node-install-local/issues/8