### PR TITLE
Add color for eastern tournaments to conform to Lila

### DIFF
--- a/src/styl/tournament.styl
+++ b/src/styl/tournament.styl
@@ -52,6 +52,8 @@
     color #3d9333
   .tournament_item.daily > &
     color #0072b2
+  .tournament_item.eastern > &
+    color #0072b2
   .tournament_item.weekly > &
     color #d55e00
   .tournament_item.monthly > &


### PR DESCRIPTION
Conform to Lila: https://github.com/ornicar/lila/blob/master/ui/tournamentSchedule/css/_schedule.scss#L96
Closes https://github.com/veloce/lichobile/issues/1362