### PR TITLE
RFC: Migrate from TSLint to ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,5 +14,6 @@ module.exports = {
   },
   "plugins": ["@typescript-eslint"],
   "rules": {
+    "@typescript-eslint/triple-slash-reference": "off"
   }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,18 @@
+module.exports = {
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -444,6 +444,68 @@
                 "minimist": "^1.2.0"
             }
         },
+        "@eslint/eslintrc": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
+            "integrity": "sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.12.4",
+                "debug": "^4.1.1",
+                "espree": "^7.3.0",
+                "globals": "^12.1.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^3.13.1",
+                "lodash": "^4.17.19",
+                "minimatch": "^3.0.4",
+                "strip-json-comments": "^3.1.1"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "debug": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "fast-deep-equal": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+                    "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+                    "dev": true
+                },
+                "globals": {
+                    "version": "12.4.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+                    "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.8.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
+        },
         "@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1450,6 +1512,12 @@
                 "acorn-walk": "^7.1.1"
             }
         },
+        "acorn-jsx": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+            "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+            "dev": true
+        },
         "acorn-walk": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
@@ -1472,6 +1540,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
             "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "dev": true
+        },
+        "ansi-colors": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
             "dev": true
         },
         "ansi-escapes": {
@@ -1683,44 +1757,6 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
             "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
             "dev": true
-        },
-        "babel-code-frame": {
-            "version": "6.26.0",
-            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-            "dev": true,
-            "requires": {
-                "chalk": "^1.1.3",
-                "esutils": "^2.0.2",
-                "js-tokens": "^3.0.2"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                    "dev": true
-                },
-                "chalk": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^2.2.1",
-                        "escape-string-regexp": "^1.0.2",
-                        "has-ansi": "^2.0.0",
-                        "strip-ansi": "^3.0.0",
-                        "supports-color": "^2.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                    "dev": true
-                }
-            }
         },
         "babel-jest": {
             "version": "26.6.3",
@@ -2242,12 +2278,6 @@
                 "delayed-stream": "~1.0.0"
             }
         },
-        "commander": {
-            "version": "2.13.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
-            "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
-            "dev": true
-        },
         "commondir": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -2693,17 +2723,20 @@
             "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
             "dev": true
         },
-        "diff": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-            "dev": true
-        },
         "diff-sequences": {
             "version": "26.6.2",
             "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.6.2.tgz",
             "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
             "dev": true
+        },
+        "doctrine": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2"
+            }
         },
         "domexception": {
             "version": "2.0.1",
@@ -2765,6 +2798,15 @@
                 "once": "^1.4.0"
             }
         },
+        "enquirer": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+            "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+            "dev": true,
+            "requires": {
+                "ansi-colors": "^4.1.1"
+            }
+        },
         "error-ex": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -2798,11 +2840,306 @@
                 "source-map": "~0.6.1"
             }
         },
+        "eslint": {
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.16.0.tgz",
+            "integrity": "sha512-iVWPS785RuDA4dWuhhgXTNrGxHHK3a8HLSMBgbbU59ruJDubUraXN8N5rn7kb8tG6sjg74eE0RA3YWT51eusEw==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@eslint/eslintrc": "^0.2.2",
+                "ajv": "^6.10.0",
+                "chalk": "^4.0.0",
+                "cross-spawn": "^7.0.2",
+                "debug": "^4.0.1",
+                "doctrine": "^3.0.0",
+                "enquirer": "^2.3.5",
+                "eslint-scope": "^5.1.1",
+                "eslint-utils": "^2.1.0",
+                "eslint-visitor-keys": "^2.0.0",
+                "espree": "^7.3.1",
+                "esquery": "^1.2.0",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^6.0.0",
+                "functional-red-black-tree": "^1.0.1",
+                "glob-parent": "^5.0.0",
+                "globals": "^12.1.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.0.0",
+                "imurmurhash": "^0.1.4",
+                "is-glob": "^4.0.0",
+                "js-yaml": "^3.13.1",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.4.1",
+                "lodash": "^4.17.19",
+                "minimatch": "^3.0.4",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.9.1",
+                "progress": "^2.0.0",
+                "regexpp": "^3.1.0",
+                "semver": "^7.2.1",
+                "strip-ansi": "^6.0.0",
+                "strip-json-comments": "^3.1.0",
+                "table": "^6.0.4",
+                "text-table": "^0.2.0",
+                "v8-compile-cache": "^2.0.3"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+                    "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^3.1.0",
+                        "shebang-command": "^2.0.0",
+                        "which": "^2.0.1"
+                    }
+                },
+                "debug": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "globals": {
+                    "version": "12.4.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+                    "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.8.1"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "levn": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+                    "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+                    "dev": true,
+                    "requires": {
+                        "prelude-ls": "^1.2.1",
+                        "type-check": "~0.4.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "optionator": {
+                    "version": "0.9.1",
+                    "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+                    "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+                    "dev": true,
+                    "requires": {
+                        "deep-is": "^0.1.3",
+                        "fast-levenshtein": "^2.0.6",
+                        "levn": "^0.4.1",
+                        "prelude-ls": "^1.2.1",
+                        "type-check": "^0.4.0",
+                        "word-wrap": "^1.2.3"
+                    }
+                },
+                "path-key": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+                    "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+                    "dev": true
+                },
+                "prelude-ls": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+                    "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "7.3.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+                    "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                },
+                "shebang-command": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+                    "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^3.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "type-check": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+                    "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+                    "dev": true,
+                    "requires": {
+                        "prelude-ls": "^1.2.1"
+                    }
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dev": true,
+            "requires": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            }
+        },
+        "eslint-utils": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+            "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "^1.1.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-visitor-keys": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+            "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+            "dev": true
+        },
+        "espree": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+            "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+            "dev": true,
+            "requires": {
+                "acorn": "^7.4.0",
+                "acorn-jsx": "^5.3.1",
+                "eslint-visitor-keys": "^1.3.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                }
+            }
+        },
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
             "dev": true
+        },
+        "esquery": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+            "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+            "dev": true,
+            "requires": {
+                "estraverse": "^5.1.0"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+                    "dev": true
+                }
+            }
+        },
+        "esrecurse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
+            "requires": {
+                "estraverse": "^5.2.0"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+                    "dev": true
+                }
+            }
         },
         "estraverse": {
             "version": "4.3.0",
@@ -3061,6 +3398,15 @@
                 "escape-string-regexp": "^1.0.5"
             }
         },
+        "file-entry-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
+            "integrity": "sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==",
+            "dev": true,
+            "requires": {
+                "flat-cache": "^3.0.4"
+            }
+        },
         "fill-range": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -3099,6 +3445,22 @@
                     }
                 }
             }
+        },
+        "flat-cache": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+            "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+            "dev": true,
+            "requires": {
+                "flatted": "^3.1.0",
+                "rimraf": "^3.0.2"
+            }
+        },
+        "flatted": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.0.tgz",
+            "integrity": "sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==",
+            "dev": true
         },
         "follow-redirects": {
             "version": "1.9.0",
@@ -3187,6 +3549,12 @@
             "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
             "dev": true
         },
+        "functional-red-black-tree": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
+        },
         "gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -3255,6 +3623,15 @@
                 "path-is-absolute": "^1.0.0"
             }
         },
+        "glob-parent": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+            "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+            "dev": true,
+            "requires": {
+                "is-glob": "^4.0.1"
+            }
+        },
         "globals": {
             "version": "11.12.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -3296,15 +3673,6 @@
             "dev": true,
             "requires": {
                 "function-bind": "^1.1.1"
-            }
-        },
-        "has-ansi": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-            "dev": true,
-            "requires": {
-                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -3444,6 +3812,30 @@
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
             "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
+        "ignore": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+            "dev": true
+        },
+        "import-fresh": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+            "dev": true,
+            "requires": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "dependencies": {
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                    "dev": true
+                }
             }
         },
         "import-local": {
@@ -3629,6 +4021,12 @@
             "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
             "dev": true
         },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
+        },
         "is-fullwidth-code-point": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -3639,6 +4037,15 @@
             "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
             "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
             "dev": true
+        },
+        "is-glob": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "dev": true,
+            "requires": {
+                "is-extglob": "^2.1.1"
+            }
         },
         "is-module": {
             "version": "1.0.0",
@@ -5104,12 +5511,6 @@
             "integrity": "sha512-T7yzBSu9PR+DqjYt+I0KVO1XTb1QhAfHnXV5Nd3xpbXM6Xg4e3vP60Q4qkNU8Fh6PHC2PivPUNN3rY7G2MxcDQ==",
             "dev": true
         },
-        "js-tokens": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-            "dev": true
-        },
         "js-yaml": {
             "version": "3.14.1",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
@@ -5188,6 +5589,12 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
             "dev": true
         },
         "json-stringify-safe": {
@@ -5613,6 +6020,13 @@
                         "lru-cache": "^6.0.0"
                     }
                 },
+                "uuid": {
+                    "version": "8.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+                    "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+                    "dev": true,
+                    "optional": true
+                },
                 "which": {
                     "version": "2.0.2",
                     "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5902,6 +6316,15 @@
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true
         },
+        "parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0"
+            }
+        },
         "parse-json": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
@@ -6093,6 +6516,12 @@
                 }
             }
         },
+        "progress": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+            "dev": true
+        },
         "prompts": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.0.tgz",
@@ -6218,6 +6647,12 @@
                 "safe-regex": "^1.1.0"
             }
         },
+        "regexpp": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+            "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+            "dev": true
+        },
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -6331,15 +6766,6 @@
             "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
             "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
             "dev": true
-        },
-        "resolve": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-            "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
-            "dev": true,
-            "requires": {
-                "path-parse": "^1.0.5"
-            }
         },
         "resolve-cwd": {
             "version": "3.0.0",
@@ -6808,6 +7234,40 @@
             "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
             "dev": true
         },
+        "slice-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^4.0.0",
+                "astral-regex": "^2.0.0",
+                "is-fullwidth-code-point": "^3.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "astral-regex": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+                    "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                }
+            }
+        },
         "snapdragon": {
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -7163,6 +7623,12 @@
             "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
             "dev": true
         },
+        "strip-json-comments": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+            "dev": true
+        },
         "stylus": {
             "version": "0.54.7",
             "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.7.tgz",
@@ -7249,6 +7715,76 @@
             "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
+        },
+        "table": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/table/-/table-6.0.4.tgz",
+            "integrity": "sha512-sBT4xRLdALd+NFBvwOz8bw4b15htyythha+q+DVZqy2RS08PPC8O2sZFgJYEY7bJvbCFKccs+WIZ/cd+xxTWCw==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.12.4",
+                "lodash": "^4.17.20",
+                "slice-ansi": "^4.0.0",
+                "string-width": "^4.2.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "fast-deep-equal": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+                    "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+                    "dev": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "lodash": {
+                    "version": "4.17.20",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+                    "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.0"
+                    }
+                }
+            }
         },
         "terminal-link": {
             "version": "2.1.1",
@@ -7346,6 +7882,12 @@
                     }
                 }
             }
+        },
+        "text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
         },
         "throat": {
             "version": "5.0.0",
@@ -7678,86 +8220,6 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
             "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
         },
-        "tslint": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.8.0.tgz",
-            "integrity": "sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=",
-            "dev": true,
-            "requires": {
-                "babel-code-frame": "^6.22.0",
-                "builtin-modules": "^1.1.1",
-                "chalk": "^2.1.0",
-                "commander": "^2.9.0",
-                "diff": "^3.2.0",
-                "glob": "^7.1.1",
-                "minimatch": "^3.0.4",
-                "resolve": "^1.3.2",
-                "semver": "^5.3.0",
-                "tslib": "^1.7.1",
-                "tsutils": "^2.12.1"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "1.9.3",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "1.1.3"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-                    "dev": true
-                },
-                "has-flag": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
-            }
-        },
-        "tsutils": {
-            "version": "2.29.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-            "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-            "dev": true,
-            "requires": {
-                "tslib": "^1.8.1"
-            }
-        },
         "tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -7902,12 +8364,11 @@
             "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
             "dev": true
         },
-        "uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true,
-            "optional": true
+        "v8-compile-cache": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+            "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
+            "dev": true
         },
         "v8-to-istanbul": {
             "version": "7.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -961,6 +961,32 @@
                 }
             }
         },
+        "@nodelib/fs.scandir": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+            "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "2.0.3",
+                "run-parallel": "^1.1.9"
+            }
+        },
+        "@nodelib/fs.stat": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+            "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+            "dev": true
+        },
+        "@nodelib/fs.walk": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+            "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.scandir": "2.1.3",
+                "fastq": "^1.6.0"
+            }
+        },
         "@rollup/plugin-alias": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-3.1.1.tgz",
@@ -1429,6 +1455,12 @@
             "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==",
             "dev": true
         },
+        "@types/json-schema": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+            "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+            "dev": true
+        },
         "@types/lodash": {
             "version": "4.14.142",
             "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.142.tgz",
@@ -1489,6 +1521,158 @@
             "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
             "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
             "dev": true
+        },
+        "@typescript-eslint/eslint-plugin": {
+            "version": "4.11.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.11.0.tgz",
+            "integrity": "sha512-x4arJMXBxyD6aBXLm3W7mSDZRiABzy+2PCLJbL7OPqlp53VXhaA1HKK7R2rTee5OlRhnUgnp8lZyVIqjnyPT6g==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/experimental-utils": "4.11.0",
+                "@typescript-eslint/scope-manager": "4.11.0",
+                "debug": "^4.1.1",
+                "functional-red-black-tree": "^1.0.1",
+                "regexpp": "^3.0.0",
+                "semver": "^7.3.2",
+                "tsutils": "^3.17.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "7.3.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+                    "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                }
+            }
+        },
+        "@typescript-eslint/experimental-utils": {
+            "version": "4.11.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.11.0.tgz",
+            "integrity": "sha512-1VC6mSbYwl1FguKt8OgPs8xxaJgtqFpjY/UzUYDBKq4pfQ5lBvN2WVeqYkzf7evW42axUHYl2jm9tNyFsb8oLg==",
+            "dev": true,
+            "requires": {
+                "@types/json-schema": "^7.0.3",
+                "@typescript-eslint/scope-manager": "4.11.0",
+                "@typescript-eslint/types": "4.11.0",
+                "@typescript-eslint/typescript-estree": "4.11.0",
+                "eslint-scope": "^5.0.0",
+                "eslint-utils": "^2.0.0"
+            }
+        },
+        "@typescript-eslint/parser": {
+            "version": "4.11.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.11.0.tgz",
+            "integrity": "sha512-NBTtKCC7ZtuxEV5CrHUO4Pg2s784pvavc3cnz6V+oJvVbK4tH9135f/RBP6eUA2KHiFKAollSrgSctQGmHbqJQ==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/scope-manager": "4.11.0",
+                "@typescript-eslint/types": "4.11.0",
+                "@typescript-eslint/typescript-estree": "4.11.0",
+                "debug": "^4.1.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
+        },
+        "@typescript-eslint/scope-manager": {
+            "version": "4.11.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.11.0.tgz",
+            "integrity": "sha512-6VSTm/4vC2dHM3ySDW9Kl48en+yLNfVV6LECU8jodBHQOhO8adAVizaZ1fV0QGZnLQjQ/y0aBj5/KXPp2hBTjA==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "4.11.0",
+                "@typescript-eslint/visitor-keys": "4.11.0"
+            }
+        },
+        "@typescript-eslint/types": {
+            "version": "4.11.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.11.0.tgz",
+            "integrity": "sha512-XXOdt/NPX++txOQHM1kUMgJUS43KSlXGdR/aDyEwuAEETwuPt02Nc7v+s57PzuSqMbNLclblQdv3YcWOdXhQ7g==",
+            "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+            "version": "4.11.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.11.0.tgz",
+            "integrity": "sha512-eA6sT5dE5RHAFhtcC+b5WDlUIGwnO9b0yrfGa1mIOIAjqwSQCpXbLiFmKTdRbQN/xH2EZkGqqLDrKUuYOZ0+Hg==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "4.11.0",
+                "@typescript-eslint/visitor-keys": "4.11.0",
+                "debug": "^4.1.1",
+                "globby": "^11.0.1",
+                "is-glob": "^4.0.1",
+                "lodash": "^4.17.15",
+                "semver": "^7.3.2",
+                "tsutils": "^3.17.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "7.3.4",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+                    "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
+                }
+            }
+        },
+        "@typescript-eslint/visitor-keys": {
+            "version": "4.11.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.11.0.tgz",
+            "integrity": "sha512-tRYKyY0i7cMk6v4UIOCjl1LhuepC/pc6adQqJk4Is3YcC6k46HvsV9Wl7vQoLbm9qADgeujiT7KdLrylvFIQ+A==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "4.11.0",
+                "eslint-visitor-keys": "^2.0.0"
+            }
         },
         "abab": {
             "version": "2.0.5",
@@ -1617,6 +1801,12 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
             "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+            "dev": true
+        },
+        "array-union": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
             "dev": true
         },
         "array-unique": {
@@ -2729,6 +2919,15 @@
             "integrity": "sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==",
             "dev": true
         },
+        "dir-glob": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
+            "requires": {
+                "path-type": "^4.0.0"
+            }
+        },
         "doctrine": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -3369,6 +3568,65 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
+        "fast-glob": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+            "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.0",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.2",
+                "picomatch": "^2.2.1"
+            },
+            "dependencies": {
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
+            }
+        },
         "fast-json-stable-stringify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -3380,6 +3638,15 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
+        },
+        "fastq": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.0.tgz",
+            "integrity": "sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==",
+            "dev": true,
+            "requires": {
+                "reusify": "^1.0.4"
+            }
         },
         "fb-watchman": {
             "version": "2.0.1",
@@ -3637,6 +3904,34 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true
+        },
+        "globby": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+            "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+            "dev": true,
+            "requires": {
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.1.1",
+                "ignore": "^5.1.4",
+                "merge2": "^1.3.0",
+                "slash": "^3.0.0"
+            },
+            "dependencies": {
+                "ignore": {
+                    "version": "5.1.8",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+                    "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+                    "dev": true
+                },
+                "slash": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+                    "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+                    "dev": true
+                }
+            }
         },
         "graceful-fs": {
             "version": "4.1.15",
@@ -5805,6 +6100,12 @@
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "dev": true
         },
+        "merge2": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+            "dev": true
+        },
         "micromatch": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
@@ -6373,6 +6674,12 @@
             "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
             "dev": true
         },
+        "path-type": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+            "dev": true
+        },
         "performance-now": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -6803,6 +7110,12 @@
             "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
             "dev": true
         },
+        "reusify": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "dev": true
+        },
         "rimraf": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -6957,6 +7270,12 @@
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
             "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="
+        },
+        "run-parallel": {
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+            "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
+            "dev": true
         },
         "rxjs": {
             "version": "6.5.3",
@@ -8219,6 +8538,15 @@
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
             "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+        },
+        "tsutils": {
+            "version": "3.17.1",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+            "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+            "dev": true,
+            "requires": {
+                "tslib": "^1.8.1"
+            }
         },
         "tunnel-agent": {
             "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
         "@rollup/plugin-node-resolve": "8.0.0",
         "@rollup/plugin-strip": "1.3.3",
         "@types/jest": "24.0.11",
+        "@typescript-eslint/eslint-plugin": "4.11.0",
+        "@typescript-eslint/parser": "4.11.0",
         "autoprefixer-stylus": "1.0.0",
         "concurrently": "5.0.0",
         "eslint": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "@types/jest": "24.0.11",
         "autoprefixer-stylus": "1.0.0",
         "concurrently": "5.0.0",
+        "eslint": "7.16.0",
         "http-server": "0.12.0",
         "jest": "^26.0.0",
         "jetifier": "1.6.5",
@@ -40,7 +41,6 @@
         "rollup-plugin-visualizer": "4.0.4",
         "stylus": "0.54.7",
         "ts-jest": "26.4.4",
-        "tslint": "5.8.0",
         "typescript": "4.1.2",
         "whatwg-fetch": "3.5.0"
     },

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "start": "concurrently 'npm run watch' 'npm run serve'",
         "serve": "http-server -p 8080 -s -g -c-1 .",
         "version": "node scripts/bump-version.js",
-        "lint": "tslint --project tsconfig.json -e '**/dts/**' -e '**/*.js'",
+        "lint": "eslint src/",
         "test": "jest",
         "i18n-update": "rimraf www/i18n/*.js && cd scripts && npm run i18n-update",
         "compile-date-locales": "node scripts/compile-date-locales",

--- a/src/chessground/Chessground.ts
+++ b/src/chessground/Chessground.ts
@@ -141,7 +141,7 @@ export default class Chessground {
       white: {pieces: {}, score: score},
       black: {pieces: {}, score: -score}
     }
-    for (let role in counts) {
+    for (const role in counts) {
       const c = counts[role]
       if (c > 0) diff.white.pieces[role] = c
       else if (c < 0) diff.black.pieces[role] = -c
@@ -222,6 +222,7 @@ export default class Chessground {
   playPremove = (): boolean => {
 
     if (this.state.premovable.current) {
+      // eslint-disable-next-line no-extra-boolean-cast
       if (Boolean(anim(board.playPremove, this))) return true
       // if the premove couldn't be played, redraw to clear it up
       this.redraw()

--- a/src/chessground/configure.ts
+++ b/src/chessground/configure.ts
@@ -88,7 +88,7 @@ function setRookCastle(state: State): void {
 }
 
 function merge(base: any, extend: any) {
-  for (let key in extend) {
+  for (const key in extend) {
     if (isObject(base[key]) && isObject(extend[key])) merge(base[key], extend[key])
     else base[key] = extend[key]
   }

--- a/src/chessground/configure.ts
+++ b/src/chessground/configure.ts
@@ -25,8 +25,8 @@ export function configureBoard(state: State, config: cg.InitConfig): void {
     state.pieces = fen.read(config.fen)
   }
 
-  if (config.hasOwnProperty('check')) board.setCheck(state, config.check || false)
-  if (config.hasOwnProperty('lastMove') && !config.lastMove) state.lastMove = null
+  if (Object.prototype.hasOwnProperty.call(config, 'check')) board.setCheck(state, config.check || false)
+  if (Object.prototype.hasOwnProperty.call(config, 'lastMove') && !config.lastMove) state.lastMove = null
 
   // fix move/premove dests
   if (state.selected) board.setSelected(state, state.selected)
@@ -58,9 +58,9 @@ export function setNewBoardState(d: State, config: cg.SetConfig): void {
   }
 
   // set check after setting turn color
-  if (config.hasOwnProperty('check')) board.setCheck(d, config.check || false)
+  if (Object.prototype.hasOwnProperty.call(config, 'check')) board.setCheck(d, config.check || false)
 
-  if (config.hasOwnProperty('lastMove') && !config.lastMove) d.lastMove = null
+  if (Object.prototype.hasOwnProperty.call(config, 'lastMove') && !config.lastMove) d.lastMove = null
   else if (config.lastMove) d.lastMove = config.lastMove
 
   // fix move/premove dests

--- a/src/chessground/fen.ts
+++ b/src/chessground/fen.ts
@@ -30,8 +30,8 @@ const letters = {
 export function read(fen: string): cg.Pieces {
   if (fen === 'start') fen = initial
   const pieces: cg.Pieces = new Map()
-  let row: number = 8
-  let col: number = 0
+  let row = 8
+  let col = 0
   for (let i = 0; i < fen.length; i++) {
     const c = fen[i]
     switch (c) {

--- a/src/chessground/fen.ts
+++ b/src/chessground/fen.ts
@@ -41,7 +41,7 @@ export function read(fen: string): cg.Pieces {
         if (row === 0) return pieces
         col = 0
         break
-      case '~':
+      case '~': {
         const k = util.pos2key([col, row] as cg.Pos)
         const p = pieces.get(k)
         if (p) {
@@ -49,7 +49,8 @@ export function read(fen: string): cg.Pieces {
           pieces.set(k, p)
         }
         break
-      default:
+      }
+      default: {
         const nb = ~~c
         if (nb) col += nb
         else {
@@ -60,6 +61,7 @@ export function read(fen: string): cg.Pieces {
             color: (c === role ? 'black' : 'white') as Color
           })
         }
+      }
     }
   }
   return pieces

--- a/src/chessground/interfaces.ts
+++ b/src/chessground/interfaces.ts
@@ -133,7 +133,7 @@ export interface PieceNode extends KeyedNode {
   cgCaptured?: boolean
   cgDragging?: boolean
 }
-export interface SquareNode extends KeyedNode { }
+export type SquareNode = KeyedNode
 
 export interface PrevData {
   orientation: Color | null

--- a/src/chessground/render.ts
+++ b/src/chessground/render.ts
@@ -54,7 +54,7 @@ export function renderBoard(d: State, dom: cg.DOM) {
   // walk over all board dom elements, apply animations and flag moved pieces
   let el = dom.board.firstChild as cg.KeyedNode
   while (el) {
-    let k = el.cgKey
+    const k = el.cgKey
     if (isPieceNode(el)) {
       pieceAtKey = pieces.get(k)
       squareClassAtKey = squares.get(k)

--- a/src/chessground/util.ts
+++ b/src/chessground/util.ts
@@ -6,7 +6,7 @@ export type Callback = (...args: any[]) => void
 export function callUserFunction(f: Callback | undefined, ...args: any[]): void {
   if (f) setTimeout(() => f(...args), 1)
 }
-export function noop() {}
+export function noop(): void { /* noop */ }
 
 export const files: readonly cg.File[] = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
 export const invFiles: readonly cg.File[] = files.slice().reverse()

--- a/src/dts/mithril.d.ts
+++ b/src/dts/mithril.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 declare namespace Mithril {
 
 	interface Lifecycle<Attrs, State> {

--- a/src/dts/mithril.d.ts
+++ b/src/dts/mithril.d.ts
@@ -70,9 +70,9 @@ declare namespace Mithril {
 
   type VnodeDOMAny = VnodeDOM<any, any>
 
-	interface CVnode<A = {}> extends Vnode<A, ClassComponent<A>> { }
+	type CVnode<A = {}> = Vnode<A, ClassComponent<A>>
 
-	interface CVnodeDOM<A = {}> extends VnodeDOM<A, ClassComponent<A>> { }
+	type CVnodeDOM<A = {}> = VnodeDOM<A, ClassComponent<A>>
 
 	/**
 	 * Components are a mechanism to encapsulate parts of a view to make code easier to organize and/or reuse.

--- a/src/dts/shepherd.d.ts
+++ b/src/dts/shepherd.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 // Type definitions for Tether-Shepherd v1.2.0
 // Project: https://github.hubspot.com/shepherd/
 // Definitions by: Matt Gibbs <https://github.com/mtgibbs>

--- a/src/http.ts
+++ b/src/http.ts
@@ -16,7 +16,7 @@ export interface ErrorResponse {
 export interface RequestOpts {
   method?: 'GET' | 'POST'
   body?: any
-  query?: Object
+  query?: Record<string, unknown>
   headers?: Record<string, string>
   cache?: RequestCache
   mode?: RequestMode

--- a/src/http.ts
+++ b/src/http.ts
@@ -26,7 +26,7 @@ export interface RequestOpts {
 
 function addQuerystring(url: string, querystring: string): string {
   const prefix = url.indexOf('?') < 0 ? '?' : '&'
-  let res = url + prefix + querystring
+  const res = url + prefix + querystring
   return res
 }
 

--- a/src/lichess/game.ts
+++ b/src/lichess/game.ts
@@ -18,7 +18,7 @@ export function parsePossibleMoves(dests?: StringMap | string): DestsMap {
     dests.split(' ').forEach(ds => {
       dec[ds.slice(0, 2)] = ds.slice(2).match(/.{2}/g) as Key[]
     })
-    else for (let k in dests) dec[k] = dests[k]!.match(/.{2}/g) as Key[]
+    else for (const k in dests) dec[k] = dests[k]!.match(/.{2}/g) as Key[]
   return dec
 }
 

--- a/src/lichess/interfaces/tournament.ts
+++ b/src/lichess/interfaces/tournament.ts
@@ -163,7 +163,7 @@ export interface TournamentLists {
 }
 
 export interface TournamentListItem {
-  readonly battle?: {}
+  readonly battle?: unknown
   readonly clock: TournamentClock
   readonly conditions: Conditions
   readonly createdBy: string

--- a/src/router.ts
+++ b/src/router.ts
@@ -22,10 +22,10 @@ const uid = (function() {
 const router = new Rlite()
 
 // unique incremented state id to determine slide direction
-let currentStateId: number = 0
+let currentStateId = 0
 let viewSlideDirection = 'fwd'
 
-let previousPath: string = '/'
+let previousPath = '/'
 
 const mountPoint = document.body
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -197,12 +197,12 @@ const savePreferences = throttle((): Promise<string> => {
 }, 1000)
 
 function lichessBackedProp<T extends PrefValue>(path: string, defaultVal: T): Prop<T> {
-  return function() {
-    if (arguments.length) {
+  return function(...args: unknown[]) {
+    if (args.length) {
       let oldPref: T
       if (session) {
         oldPref = <T>getAtPath(session, path)
-        setAtPath(session, path, arguments[0])
+        setAtPath(session, path, args[0])
       }
       savePreferences()
       .catch((err) => {

--- a/src/session.ts
+++ b/src/session.ts
@@ -96,7 +96,7 @@ function getUserId(): string | undefined {
 }
 
 function nowPlaying(): NowPlayingGame[] {
-  let np = session && session.nowPlaying || []
+  const np = session && session.nowPlaying || []
   return np.filter(e =>
     settings.game.supportedVariants.indexOf(e.variant.key) !== -1
   )

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -81,8 +81,8 @@ export const SEEKING_SOCKET_NAME = 'seekLobby'
 // connectedWS means connection is established and server ping/pong
 // is working normally
 let connectedWS = false
-let currentMoveLatency: number = 0
-let currentPingInterval: number = 2000
+let currentMoveLatency = 0
+let currentPingInterval = 2000
 let rememberedSetups: Array<ConnectionSetup> = []
 
 const worker = new Worker('lib/socketWorker.js')
@@ -146,7 +146,7 @@ function setupConnection(setup: SocketSetup, socketHandlers: SocketHandlers) {
         if (socketHandlers.onError) socketHandlers.onError()
         break
       case 'handle':
-        let h = socketHandlers.events[msg.data.payload.t]
+        const h = socketHandlers.events[msg.data.payload.t]
         if (h) h(msg.data.payload.d, msg.data.payload)
         break
       case 'pingInterval':
@@ -244,7 +244,7 @@ function createTournament(
   handlers: MessageHandlers,
   featuredGameId?: string
 ): SocketIFace {
-  let url = '/tournament/' + tournamentId + `/socket/v${globalConfig.apiVersion}`
+  const url = '/tournament/' + tournamentId + `/socket/v${globalConfig.apiVersion}`
   const socketHandlers = {
     events: Object.assign({}, defaultHandlers, handlers),
     onOpen: session.backgroundRefresh

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -19,7 +19,7 @@ export interface LichessMessage<T> {
   d?: T
 }
 
-export type LichessMessageAny = LichessMessage<{}>
+export type LichessMessageAny = LichessMessage<unknown>
 
 interface Options {
   name: string
@@ -145,10 +145,11 @@ function setupConnection(setup: SocketSetup, socketHandlers: SocketHandlers) {
       case 'onError':
         if (socketHandlers.onError) socketHandlers.onError()
         break
-      case 'handle':
+      case 'handle': {
         const h = socketHandlers.events[msg.data.payload.t]
         if (h) h(msg.data.payload.d, msg.data.payload)
         break
+      }
       case 'pingInterval':
         currentPingInterval = msg.data.payload
         break
@@ -166,6 +167,8 @@ function send<D, O>(url: string , t: string, data?: D, opts?: O): void {
 
 function ask<D, O, R>(url: string, t: string, listenTo: string, data?: D, opts?: O): Promise<R> {
   return new Promise((resolve, reject) => {
+    // eslint is wrong, this gets reassigned at the end of the function
+    // eslint-disable-next-line prefer-const
     let tid: number
     function listen(e: MessageEvent) {
       if (e.data.topic === 'handle' && e.data.payload.t === listenTo) {
@@ -430,7 +433,7 @@ function redirectToGame(obj: string | RedirectObj) {
   else {
     url = obj.url
     if (obj.cookie) {
-      const domain = document.domain.replace(/^.+(\.[^\.]+\.[^\.]+)$/, '$1')
+      const domain = document.domain.replace(/^.+(\.[^.]+\.[^.]+)$/, '$1')
       const cookie = [
         encodeURIComponent(obj.cookie.name) + '=' + obj.cookie.value,
         '; max-age=' + obj.cookie.maxAge,

--- a/src/sound.ts
+++ b/src/sound.ts
@@ -51,7 +51,7 @@ export default {
       Plugins.SoundEffect.loadSound({ id: 'berserk', path: `sounds/berserk${ext}` }),
       Plugins.SoundEffect.loadSound({ id: 'clock', path: `sounds/clock${ext}` }),
       Plugins.SoundEffect.loadSound({ id: 'confirmation', path: `sounds/confirmation${ext}` }),
-    ]).then(() => {})
+    ]).then(() => { /* noop */ })
   },
   move() {
     if (shouldPlay) Plugins.SoundEffect.play({ id: 'move' })

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -2,7 +2,7 @@ function withStorage<T>(f: (s: Storage) => T | void): T | void | null {
   // can throw an exception when storage is full
   try {
     return window.localStorage ? f(window.localStorage) : null
-  } catch (e) {}
+  } catch (e) { /* noop */ }
 }
 
 export default {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,7 +1,7 @@
 function withStorage<T>(f: (s: Storage) => T | void): T | void | null {
   // can throw an exception when storage is full
   try {
-    return !!window.localStorage ? f(window.localStorage) : null
+    return window.localStorage ? f(window.localStorage) : null
   } catch (e) {}
 }
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -173,6 +173,6 @@ export function setStatusBarStyle(bgTheme: string): Promise<void> {
     // Plugins.StatusBar.setOverlaysWebView({
     //   overlay: isTransparent(bgTheme)
     // }),
-  ]).then(() => {})
+  ]).then(() => { /* noop */ })
 }
 

--- a/src/ui/about.tsx
+++ b/src/ui/about.tsx
@@ -58,7 +58,7 @@ export default {
       </div>
     )
   }
-} as Mithril.Component<{}, {}>
+} as Mithril.Component
 
 
 function externalLink(text: string, url: string): Mithril.Child {

--- a/src/ui/ai/AiRound.ts
+++ b/src/ui/ai/AiRound.ts
@@ -321,11 +321,10 @@ export default class AiRound implements AiRoundInterface, PromotingInterface {
   }
 
   public onGameEnd = () => {
-    const self = this
     this.chessground.cancelMove()
     this.chessground.stop()
-    setTimeout(function() {
-      self.actions.open()
+    setTimeout(() => {
+      this.actions.open()
       redraw()
     }, 500)
   }

--- a/src/ui/analyse/AnalyseCtrl.ts
+++ b/src/ui/analyse/AnalyseCtrl.ts
@@ -68,7 +68,7 @@ export default class AnalyseCtrl {
   mainline!: Tree.Node[]
 
   // state flags
-  onMainline: boolean = true
+  onMainline = true
   synthetic: boolean // false if coming from a real game
   ongoing: boolean // true if real game is ongoing
 
@@ -78,13 +78,13 @@ export default class AnalyseCtrl {
   contextMenu: Tree.Path | null = null
 
   // various view state flags
-  replaying: boolean = false
+  replaying = false
   cgConfig?: cg.SetConfig
-  analysisProgress: boolean = false
-  retroGlowing: boolean = false
+  analysisProgress = false
+  retroGlowing = false
   formattedDate?: string
 
-  private _currentTabIndex: number = 0
+  private _currentTabIndex = 0
 
   private debouncedExplorerSetStep: () => void
 
@@ -698,7 +698,7 @@ export default class AnalyseCtrl {
       fen: node.fen,
       turnColor: color,
       orientation: this.settings.s.flip ? oppositeColor(this.orientation) : this.orientation,
-      movableColor: Boolean(this.gameOver()) ? null : color,
+      movableColor: this.gameOver() ? null : color,
       dests: dests || null,
       check: !!node.check,
       lastMove: node.uci ? chessFormat.uciToMoveOrDrop(node.uci) : null
@@ -731,7 +731,7 @@ export default class AnalyseCtrl {
         if (path === this.path) {
           this.updateBoard()
           redraw()
-          if (Boolean(this.gameOver())) this.stopCevalImmediately()
+          if (this.gameOver()) this.stopCevalImmediately()
         }
       })
       .catch(err => console.error('get dests error', err))
@@ -744,7 +744,7 @@ export default class AnalyseCtrl {
       this.node.ply <= 20 && this.node.ply > 0 &&
       openingSensibleVariants.has(this.data.game.variant.key)
     ) {
-      let msg: { fen: string, path: string, variant?: VariantKey } = {
+      const msg: { fen: string, path: string, variant?: VariantKey } = {
         fen: this.node.fen,
         path: this.path
       }

--- a/src/ui/analyse/analyse.ts
+++ b/src/ui/analyse/analyse.ts
@@ -146,7 +146,7 @@ export default {
         } else {
           backButton = renderBackbutton([
             h(GameTitle, { data: this.ctrl.data, subTitle: 'date' }),
-            bookmarkButton(this.ctrl.toggleBookmark, this.ctrl.data.bookmarked!!),
+            bookmarkButton(this.ctrl.toggleBookmark, this.ctrl.data.bookmarked!),
           ])
         }
       }

--- a/src/ui/analyse/ceval/StockfishEngine.ts
+++ b/src/ui/analyse/ceval/StockfishEngine.ts
@@ -1,4 +1,4 @@
-import { Tree } from '../../shared/tree/interfaces'
+import * as Tree from '../../shared/tree/interfaces'
 import { Work, IEngine } from './interfaces'
 import { send, setOption, setVariant } from '../../../utils/stockfish'
 

--- a/src/ui/analyse/ceval/cevalView.tsx
+++ b/src/ui/analyse/ceval/cevalView.tsx
@@ -88,7 +88,7 @@ function renderCevalPvs(ctrl: AnalyseCtrl) {
   }
 }
 
-export const EvalBox: Mithril.Component<{ ctrl: AnalyseCtrl }, {}> = {
+export const EvalBox: Mithril.Component<{ ctrl: AnalyseCtrl }> = {
   onbeforeupdate({ attrs }) {
     return !attrs.ctrl.replaying
   },

--- a/src/ui/analyse/charts/acpl.ts
+++ b/src/ui/analyse/charts/acpl.ts
@@ -2,7 +2,7 @@ import { select } from 'd3-selection'
 import { scaleLinear } from 'd3-scale'
 import { area as d3Area } from 'd3-shape'
 
-import { Tree } from '../../shared/tree/interfaces'
+import * as Tree from '../../shared/tree/interfaces'
 import { AnalyseData } from '../../../lichess/interfaces/analyse'
 
 interface Point {

--- a/src/ui/analyse/charts/moveTimes.ts
+++ b/src/ui/analyse/charts/moveTimes.ts
@@ -84,7 +84,7 @@ export default function drawMoveTimesChart(
   .y0(y(0))
   .y1(d => y(d.y))
 
-  const maxCentis = Math.max.apply(Math, moveCentis) / 100
+  const maxCentis = Math.max(...moveCentis) / 100
   const legendScale = scaleLinear()
   .domain([-maxCentis, maxCentis])
   .rangeRound([height, 0])

--- a/src/ui/analyse/explorer/OpeningTable.tsx
+++ b/src/ui/analyse/explorer/OpeningTable.tsx
@@ -15,7 +15,7 @@ export interface Attrs {
   data: OpeningData
 }
 
-const OpeningTable: Mithril.Component<Attrs, {}> = {
+const OpeningTable: Mithril.Component<Attrs> = {
   onbeforeupdate({ attrs }, { attrs: oldattrs }) {
     return attrs.data !== oldattrs.data
   },

--- a/src/ui/analyse/explorer/explorerView.tsx
+++ b/src/ui/analyse/explorer/explorerView.tsx
@@ -55,7 +55,7 @@ function onTablebaseTap(ctrl: AnalyseCtrl, e: Event) {
 }
 
 function showTablebase(ctrl: AnalyseCtrl, title: string, moves: readonly TablebaseMoveStats[], fen: string) {
-  let stm = fen.split(/\s/)[1]
+  const stm = fen.split(/\s/)[1]
   if (!moves.length) return null
   return [
     <div className="title">{title}</div>,
@@ -102,7 +102,7 @@ function showDtz(stm: string, move: TablebaseMoveStats) {
   else if (move.dtz === null) return null
   else if (move.dtz === 0) return h('result.draws', i18n('draw'))
   else if (move.zeroing) {
-    let capture = move.san.indexOf('x') !== -1
+    const capture = move.san.indexOf('x') !== -1
     if (capture) return h('result.' + winner(stm, move), i18n('capture'))
     else return h('result.' + winner(stm, move), i18n('pawnMove'))
   }

--- a/src/ui/analyse/nodeFinder.ts
+++ b/src/ui/analyse/nodeFinder.ts
@@ -1,5 +1,5 @@
 import * as winningChances from './ceval/winningChances'
-import { Tree } from '../shared/tree/interfaces'
+import * as Tree from '../shared/tree/interfaces'
 
 function hasCompChild(node: Tree.Node): boolean {
   return !!node.children.find(function(c) {

--- a/src/ui/analyse/nodeFinder.ts
+++ b/src/ui/analyse/nodeFinder.ts
@@ -43,7 +43,7 @@ export function detectThreefold(nodeList: Tree.Node[], node: Tree.Node): void {
   if (node.threefold !== undefined) return
   const currentFen = threefoldFen(node.fen)
   let nbSimilarPositions = 0
-  for (let i in nodeList)
+  for (const i in nodeList)
     if (threefoldFen(nodeList[i].fen) === currentFen)
       nbSimilarPositions++
   node.threefold = nbSimilarPositions > 2

--- a/src/ui/analyse/practice/practiceCtrl.ts
+++ b/src/ui/analyse/practice/practiceCtrl.ts
@@ -72,7 +72,7 @@ export function make(root: AnalyseCtrl, playableDepth: () => number): PracticeCt
     }
   }
 
-  function commentable(node: Tree.Node, bonus: number = 0): boolean {
+  function commentable(node: Tree.Node, bonus = 0): boolean {
     if (root.gameOver(node) || node.tbhit) return true
     const ceval = node.ceval
     return ceval ? ((ceval.depth + bonus) >= 15 || (ceval.depth >= 13 && Number(ceval.millis) > 3000)) : false

--- a/src/ui/analyse/view/Clock.ts
+++ b/src/ui/analyse/view/Clock.ts
@@ -12,7 +12,6 @@ export default {
     if (clock === undefined) return
     const parentClock = ctrl.tree.getParentClock(node, ctrl.path)
     let whiteCentis, blackCentis
-    let centis
     const isWhiteTurn = node.ply % 2 === 0
     if (isWhiteTurn) {
       whiteCentis = parentClock
@@ -22,14 +21,14 @@ export default {
       whiteCentis = clock
       blackCentis = parentClock
     }
-    centis = color === 'white' ? whiteCentis! : blackCentis!
+    const centis = color === 'white' ? whiteCentis! : blackCentis!
     const current = color === 'white' ? isWhiteTurn : !isWhiteTurn
 
     return h('span.analyse-clock', {
       className: current ? 'current' : '',
     }, clockContent(centis))
   }
-} as Mithril.Component<{ ctrl: AnalyseCtrl, color: Color }, {}>
+} as Mithril.Component<{ ctrl: AnalyseCtrl, color: Color }>
 
 function clockContent(centis: number): Mithril.Child {
   if (centis === undefined) return h('span.time', ['-'])

--- a/src/ui/analyse/view/Replay.ts
+++ b/src/ui/analyse/view/Replay.ts
@@ -35,7 +35,7 @@ export default {
       }, getMoveEl, false)
     }, renderTree(ctrl))
   }
-} as Mithril.Component<Attrs, {}>
+} as Mithril.Component<Attrs>
 
 function onReplayTap(ctrl: AnalyseCtrl, e: Event) {
   const el = getMoveEl(e)

--- a/src/ui/analyse/view/analysisView.ts
+++ b/src/ui/analyse/view/analysisView.ts
@@ -56,7 +56,7 @@ const AcplSummary: Mithril.Component<{
   d: AnalyseData
   analysis: RemoteEvalSummary
   study?: Study
-}, {}> = {
+}> = {
   onbeforeupdate({ attrs }, { attrs: oldattrs }) {
     return !shallowEqual(attrs.analysis, oldattrs.analysis)
   },

--- a/src/ui/clock/ChessClockCtrl.ts
+++ b/src/ui/clock/ChessClockCtrl.ts
@@ -19,7 +19,7 @@ export interface IChessClockCtrl {
   appStateListener: PluginListenerHandle
 }
 
-function noop() {}
+function noop() { /* noop */ }
 
 export default function ChessClockCtrl(): IChessClockCtrl {
 

--- a/src/ui/clock/clock.ts
+++ b/src/ui/clock/clock.ts
@@ -10,7 +10,8 @@ interface State {
   ctrl: IChessClockCtrl
 }
 
-const ChessClockScreen: Mithril.Component<{}, State> = {
+
+const ChessClockScreen: Mithril.Component<Record<string, never>, State> = {
   oncreate: helper.viewFadeIn,
 
   oninit() {

--- a/src/ui/gamesMenu.ts
+++ b/src/ui/gamesMenu.ts
@@ -322,7 +322,7 @@ function renderAllGames() {
     renderSendingChallenge(c)
   )
 
-  let allCards = [
+  const allCards = [
     ...challengesDom,
     ...(nowPlaying.map(g => renderGame(g))),
     ...sendingChallengesDom,

--- a/src/ui/helper/Siema.js
+++ b/src/ui/helper/Siema.js
@@ -55,8 +55,8 @@ export default class Siema {
       // multipleDrag: true,
       threshold: 20,
       rtl: false,
-      onInit: () => {},
-      onChange: () => {},
+      onInit: () => { /* noop */ },
+      onChange: () => { /* noop */ },
     };
 
     const userSttings = options;

--- a/src/ui/helper/button.ts
+++ b/src/ui/helper/button.ts
@@ -51,11 +51,11 @@ export default function ButtonHandler(
   }
 
   function onTouchStart(e: TouchEvent) {
-    let touch = e.changedTouches[0]
+    const touch = e.changedTouches[0]
     activeElement  = getElement ? getElement(e) : el
     if (!activeElement) return
     if ((activeElement as HTMLButtonElement).disabled === true) return
-    let boundingRect = activeElement.getBoundingClientRect()
+    const boundingRect = activeElement.getBoundingClientRect()
     startX = touch.clientX
     startY = touch.clientY
     boundaries = {
@@ -77,7 +77,7 @@ export default function ButtonHandler(
   function onTouchMove(e: TouchEvent) {
     // if going out of bounds, no way to reenable the button
     if (active && activeElement) {
-      let touch = e.changedTouches[0]
+      const touch = e.changedTouches[0]
       active = isActive(touch)
       if (!active) {
         clearTimeout(holdTimeoutID)

--- a/src/ui/helper/button.ts
+++ b/src/ui/helper/button.ts
@@ -130,10 +130,10 @@ export default function ButtonHandler(
   }
 
   function isActive(touch: Touch) {
-    let x = touch.clientX,
+     const x = touch.clientX,
       y = touch.clientY,
-      b = boundaries,
-      dX = 0,
+      b = boundaries;
+    let dX = 0,
       dY = 0
     if (scrollX) dX = Math.abs(x - startX)
     if (scrollY) dY = Math.abs(y - startY)

--- a/src/ui/helper/index.ts
+++ b/src/ui/helper/index.ts
@@ -47,7 +47,7 @@ export function onPageLeave(anim: (el: HTMLElement) => Promise<void>, cleanup?: 
 
 // el fade in transition, can be applied to any element
 export function elFadeIn(el: HTMLElement, duration = animDuration, origOpacity = '0.5', endOpacity = '1') {
-  let tId: number
+  let tId: number | undefined = undefined
 
   el.style.opacity = origOpacity
   el.style.transition = `opacity ${duration}ms ease-out`
@@ -73,10 +73,10 @@ export function elFadeIn(el: HTMLElement, duration = animDuration, origOpacity =
 // apply only to page change transitions
 // they listen to history to determine if animation is going forward or backward
 export function pageSlideIn(el: HTMLElement) {
-  let tId: number
+  let tId: number | undefined = undefined
 
   function after() {
-    clearTimeout(tId)
+    clearTimeout(tId )
     if (el) {
       el.removeAttribute('style')
       el.removeEventListener('transitionend', after, false)
@@ -97,7 +97,7 @@ export function pageSlideIn(el: HTMLElement) {
 }
 
 export function elSlideIn(el: HTMLElement, dir: 'left' | 'right') {
-  let tId: number
+  let tId: number | undefined = undefined
 
   function after() {
     clearTimeout(tId)

--- a/src/ui/helper/index.ts
+++ b/src/ui/helper/index.ts
@@ -139,8 +139,8 @@ export function findParentBySelector(el: HTMLElement, selector: string): HTMLEle
 export function viewportDim(): ViewportDim {
   if (cachedViewportDim) return cachedViewportDim
 
-  let e = document.documentElement
-  let vpd = cachedViewportDim = {
+  const e = document.documentElement
+  const vpd = cachedViewportDim = {
     vw: e.clientWidth,
     vh: e.clientHeight
   }
@@ -268,7 +268,7 @@ export function progress(p: number): Mithril.Children {
 
 export function classSet(classes: {[cl: string]: boolean}): string {
   const arr: string[] = []
-  for (let i in classes) {
+  for (const i in classes) {
     if (classes[i]) arr.push(i)
   }
   return arr.join(' ')

--- a/src/ui/home/HomeCtrl.ts
+++ b/src/ui/home/HomeCtrl.ts
@@ -22,7 +22,7 @@ import { dailyPuzzle as dailyPuzzleXhr, featuredTournaments as featuredTournamen
 export default class HomeCtrl {
   public selectedTab: number
 
-  public isScrolling: boolean = false
+  public isScrolling = false
 
   public socket?: SocketIFace
 

--- a/src/ui/home/HomeCtrl.ts
+++ b/src/ui/home/HomeCtrl.ts
@@ -132,7 +132,7 @@ export default class HomeCtrl {
   }
 
   public onTabChange = (i: number) => {
-    const loc = window.location.search.replace(/\?tab\=\w+$/, '')
+    const loc = window.location.search.replace(/\?tab=\w+$/, '')
     try {
       window.history.replaceState(window.history.state, '', loc + '?tab=' + i)
     } catch (e) { console.error(e) }

--- a/src/ui/home/homeView.tsx
+++ b/src/ui/home/homeView.tsx
@@ -151,9 +151,9 @@ function spreadNumber(
     if (overrideNbSteps) nbSteps = Math.abs(overrideNbSteps)
     timeouts.forEach(clearTimeout)
     timeouts = []
-    let prev = previous === 0 ? 0 : (previous || nb)
+    const prev = previous === 0 ? 0 : (previous || nb)
     previous = nb
-    let interv = Math.abs(getDuration() / nbSteps)
+    const interv = Math.abs(getDuration() / nbSteps)
     for (let i = 0; i < nbSteps; i++) {
       timeouts.push(
         setTimeout(() => display(el, prev, nb, i), Math.round(i * interv))

--- a/src/ui/importer/importer.ts
+++ b/src/ui/importer/importer.ts
@@ -13,7 +13,7 @@ interface State {
   ctrl: IImporterCtrl
 }
 
-const ImporterScreen: Mithril.Component<{}, State> = {
+const ImporterScreen: Mithril.Component<Record<string, never>, State> = {
   oninit() {
     socket.createDefault()
     this.ctrl = ImporterCtrl()

--- a/src/ui/inbox/inbox.ts
+++ b/src/ui/inbox/inbox.ts
@@ -77,4 +77,4 @@ export default {
     const footer = renderFooter(this.ctrl)
     return layout.free(headerEl, body, footer)
   }
-} as Mithril.Component<{}, { ctrl: InboxCtrl }>
+} as Mithril.Component<Record<string, never>, { ctrl: InboxCtrl }>

--- a/src/ui/loginModal.ts
+++ b/src/ui/loginModal.ts
@@ -62,7 +62,7 @@ export default {
               h('input#token[type=number]', {
                 className: formError !== 'MissingTotpToken' ? 'form-error' : '',
                 placeholder: i18n('authenticationCode'),
-                pattern: '\d{6}',
+                pattern: '\\d{6}',
                 required: true
               }),
             ]),

--- a/src/ui/menu/menuView.tsx
+++ b/src/ui/menu/menuView.tsx
@@ -39,7 +39,7 @@ export default {
       </aside>
     )
   }
-} as Mithril.Component<{}, {}>
+} as Mithril.Component
 
 function renderHeader(user?: Session) {
   const caretClass = menu.profileMenuOpen() ? 'up' : 'down'

--- a/src/ui/players/PlayersCtrl.ts
+++ b/src/ui/players/PlayersCtrl.ts
@@ -32,7 +32,7 @@ export default class PlayersCtrl {
   }
 
   public onTabChange = (tabIndex: number) => {
-    const loc = window.location.search.replace(/\?tab\=\w+$/, '')
+    const loc = window.location.search.replace(/\?tab=\w+$/, '')
     try {
       window.history.replaceState(window.history.state, '', loc + '?tab=' + tabIndex)
     } catch (e) { console.error(e) }

--- a/src/ui/players/PlayersCtrl.ts
+++ b/src/ui/players/PlayersCtrl.ts
@@ -8,7 +8,7 @@ import * as xhr from './playerXhr'
 export default class PlayersCtrl {
   public currentTab: number
 
-  public isSearchOpen: boolean = false
+  public isSearchOpen = false
   public searchResults: readonly string[] = []
   public players?: readonly User[]
   public leaderboard?: Rankings

--- a/src/ui/search/searchXhr.ts
+++ b/src/ui/search/searchXhr.ts
@@ -1,7 +1,7 @@
 import { fetchJSON } from '../../http'
 import { SearchQuery, SearchResult } from './interfaces'
 
-export function search(query: SearchQuery, page: number = 1): Promise<SearchResult> {
+export function search(query: SearchQuery, page = 1): Promise<SearchResult> {
   return fetchJSON('/games/search', {
     method: 'GET',
     query: Object.assign({}, query, { page })

--- a/src/ui/settings/background.ts
+++ b/src/ui/settings/background.ts
@@ -22,7 +22,7 @@ interface State {
 
 let timeoutId: number
 
-const ThemePrefScreen: Mithril.Component<{}, State> = {
+const ThemePrefScreen: Mithril.Component<Record<string, never>, State> = {
   oncreate: helper.viewSlideIn,
 
   oninit() {

--- a/src/ui/settings/boardTheme.ts
+++ b/src/ui/settings/boardTheme.ts
@@ -71,7 +71,7 @@ export default {
     const header = dropShadowHeader(null, backButton(i18n('boardTheme')))
     return layout.free(header, renderBody(this))
   }
-} as Mithril.Component<{}, State>
+} as Mithril.Component<Record<string, never>, State>
 
 function renderBody(state: State) {
 

--- a/src/ui/settings/clock.ts
+++ b/src/ui/settings/clock.ts
@@ -21,7 +21,7 @@ export default {
         )
     ))
   }
-} as Mithril.Component<{}, {}>
+} as Mithril.Component
 
 function renderAppPrefs() {
   return [

--- a/src/ui/settings/gameBehavior.ts
+++ b/src/ui/settings/gameBehavior.ts
@@ -21,7 +21,7 @@ export default {
         )
     ))
   }
-} as Mithril.Component<{}, {}>
+} as Mithril.Component
 
 function renderAppPrefs() {
   return [

--- a/src/ui/settings/gameDisplay.ts
+++ b/src/ui/settings/gameDisplay.ts
@@ -14,7 +14,7 @@ export default {
     const header = dropShadowHeader(null, backButton(i18n('gameDisplay')))
     return layout.free(header, renderBody())
   }
-} as Mithril.Component<{}, {}>
+} as Mithril.Component
 
 function renderBody() {
   return [

--- a/src/ui/settings/lang.tsx
+++ b/src/ui/settings/lang.tsx
@@ -26,9 +26,8 @@ export default {
   },
 
   view() {
-    const ctrl = this
     const header = dropShadowHeader(null, backButton(i18n('language')))
-    const currentLang = ctrl.lang
+    const currentLang = this.lang
 
     function renderLang(l: string) {
       const name = getLanguageNativeName(getIsoCodeFromLocale(l))
@@ -43,25 +42,25 @@ export default {
       )
     }
 
-    function onTap(e: Event) {
+    const onTap = (e: Event) => {
       const el = helper.getLI(e)
       const lang = el && el.dataset.lang
       if (lang) {
         setServerLang(lang)
         loadLanguage(lang).then(() => {
-          ctrl.lang = lang
+          this.lang = lang
           redraw()
         })
       }
     }
 
-    function renderBody() {
-      return ctrl.locales ?
+    const renderBody = () => {
+      return this.locales ?
         <ul
           className="native_scroller page settings_list"
           oncreate={helper.ontapY(onTap, undefined, helper.getLI)}
         >
-          {ctrl.locales.map(l => renderLang(l))}
+          {this.locales.map(l => renderLang(l))}
         </ul> :
         <div
           className="loader_container"
@@ -73,4 +72,4 @@ export default {
 
     return layout.free(header, renderBody())
   }
-} as Mithril.Component<{}, State>
+} as Mithril.Component<Record<string, never>, State>

--- a/src/ui/settings/settings.ts
+++ b/src/ui/settings/settings.ts
@@ -28,7 +28,7 @@ export default {
     const header = dropShadowHeader(null, backButton(i18n('settings')))
     return layout.free(header, renderBody(this.appVersion))
   }
-} as Mithril.Component<{}, State>
+} as Mithril.Component<Record<string, never>, State>
 
 function renderBody(appVersion?: string) {
   return [

--- a/src/ui/shared/GameItem.tsx
+++ b/src/ui/shared/GameItem.tsx
@@ -119,7 +119,7 @@ function renderBoard(fen: string, orientation: Color, boardTheme: string) {
 }
 
 function renderPlayer(players: { white: UserGamePlayer, black: UserGamePlayer}, color: Color) {
-  let player = players[color]
+  const player = players[color]
   let playerName: string
   if (player.user) playerName = playerApi.lightPlayerName(player.user)
   else if (player.aiLevel) {

--- a/src/ui/shared/GameItem.tsx
+++ b/src/ui/shared/GameItem.tsx
@@ -90,7 +90,7 @@ export default {
       </li>
     )
   }
-} as Mithril.Component<Attrs, {}>
+} as Mithril.Component<Attrs>
 
 function renderBoard(fen: string, orientation: Color, boardTheme: string) {
 

--- a/src/ui/shared/GameTitle.ts
+++ b/src/ui/shared/GameTitle.ts
@@ -90,4 +90,4 @@ export default {
     ])
   }
 
-} as Mithril.Component<Attrs, {}>
+} as Mithril.Component<Attrs>

--- a/src/ui/shared/PlayerPopup.tsx
+++ b/src/ui/shared/PlayerPopup.tsx
@@ -37,7 +37,7 @@ export default {
       close
     ) : null
   }
-} as Mithril.Component<Attrs, {}>
+} as Mithril.Component<Attrs>
 
 function content(mini: any, player: Player, opponent: Player, score?: Score) {
   const user = player.user

--- a/src/ui/shared/chat.ts
+++ b/src/ui/shared/chat.ts
@@ -69,7 +69,7 @@ export class Chat {
 
   public selectLines() {
     let prev: ChatMsg
-    let ls: ChatMsg[] = []
+    const ls: ChatMsg[] = []
     this.lines.forEach((line: ChatMsg) => {
       if (this.isLegitMsg(line) &&
         (!prev || !compactableDeletedLines(prev, line))
@@ -192,7 +192,7 @@ function renderPlayerMsg(player: Player, msg: ChatMsg, i: number, all: ChatMsg[]
     player.user && msg.u === player.user.username
 
   let closeBalloon = true
-  let next = all[i + 1]
+  const next = all[i + 1]
   let nextTalking
   if (next) {
     nextTalking = next.c ? next.c === player.color :

--- a/src/ui/shared/clock/utils.tsx
+++ b/src/ui/shared/clock/utils.tsx
@@ -24,7 +24,7 @@ export function isStageClock(c: IChessClock): c is IStageClock {
 }
 
 export function addStage (stagesSetting: Prop<Array<StageSetting>>) {
-  let stages = stagesSetting()
+  const stages = stagesSetting()
   stages[stages.length - 1].moves = stages[stages.length - 2].moves
   stages.push({time: stages[stages.length - 1].time, moves: null})
   stagesSetting(stages)
@@ -32,7 +32,7 @@ export function addStage (stagesSetting: Prop<Array<StageSetting>>) {
 }
 
 export function removeStage (stagesSetting: Prop<Array<StageSetting>>) {
-  let stages = stagesSetting()
+  const stages = stagesSetting()
   if (stages.length <= 2)
     return
   stages.pop()
@@ -160,7 +160,7 @@ function renderStage(onChange: () => void, index: number) {
 }
 
 function updateTime(index: number, time: string) {
-  let stages = settings.clock.stage.stages()
+  const stages = settings.clock.stage.stages()
 
   if (time) {
     stages[index].time = time
@@ -170,7 +170,7 @@ function updateTime(index: number, time: string) {
 }
 
 function updateMoves (index: number, moves: string) {
-  let stages = settings.clock.stage.stages()
+  const stages = settings.clock.stage.stages()
   if (moves) {
     stages[index].moves = moves
     settings.clock.stage.stages(stages)

--- a/src/ui/shared/form.ts
+++ b/src/ui/shared/form.ts
@@ -102,7 +102,7 @@ export default {
     label: string,
     options: ReadonlyArray<MultiOption<T>>,
     prop: Prop<T>,
-    wrap: boolean = false,
+    wrap = false,
     callback?: (v: T) => void,
   ) {
     const selected = prop()

--- a/src/ui/shared/offlineRound/view.tsx
+++ b/src/ui/shared/offlineRound/view.tsx
@@ -209,7 +209,7 @@ function pad2(num: number): string {
 
 const sepHigh = ':'
 const sepLow = ' '
-function formatClockTime(time: Millis, isRunning: boolean = false) {
+function formatClockTime(time: Millis, isRunning = false) {
   const date = new Date(time)
   const millis = date.getUTCMilliseconds()
   const minutes = pad2(date.getUTCMinutes())
@@ -221,7 +221,7 @@ function formatClockTime(time: Millis, isRunning: boolean = false) {
     return hours + pulse + minutes
   }
   if (time < 10000) {
-    let tenthsStr = Math.floor(millis / 100).toString()
+    const tenthsStr = Math.floor(millis / 100).toString()
     return [minutes + sepHigh + seconds, h('tenths', '.' + tenthsStr)]
   }
 

--- a/src/ui/shared/popup.tsx
+++ b/src/ui/shared/popup.tsx
@@ -3,12 +3,12 @@ import * as utils from '../../utils'
 import * as helper from '../helper'
 
 export default function popup(
-  classes: object | string,
+  classes: Record<string, boolean> | string,
   headerF: (() => Mithril.Children) | undefined,
   contentF: () => Mithril.Children,
   isShowing: boolean,
   closef?: () => void
-) {
+): Mithril.Vnode | null {
   if (!isShowing) {
     return null
   }

--- a/src/ui/shared/round/OnlineRound.ts
+++ b/src/ui/shared/round/OnlineRound.ts
@@ -83,7 +83,7 @@ export default class OnlineRound implements OnlineRoundInterface {
     readonly goingBack: boolean,
     readonly id: string,
     cfg: OnlineGameData,
-    flipped: boolean = false,
+    flipped = false,
     readonly onFeatured?: () => void,
     userTv?: string,
   ) {
@@ -322,7 +322,7 @@ export default class OnlineRound implements OnlineRoundInterface {
       ((this.data.game.turns - this.data.game.startedAtTurn) > 1 || this.data.clock.running)
   }
 
-  public sendMove(orig: Key, dest: Key, prom?: Role, isPremove: boolean = false) {
+  public sendMove(orig: Key, dest: Key, prom?: Role, isPremove = false) {
     const move = {
       u: orig + dest
     }
@@ -428,8 +428,8 @@ export default class OnlineRound implements OnlineRoundInterface {
       d.game.winner = o.winner
     }
 
-    let wDraw = white.offeringDraw
-    let bDraw = black.offeringDraw
+    const wDraw = white.offeringDraw
+    const bDraw = black.offeringDraw
     if (!wDraw && o.wDraw) {
       sound.dong()
       vibrate.quick()

--- a/src/ui/shared/round/__tests__/backoff.test.ts
+++ b/src/ui/shared/round/__tests__/backoff.test.ts
@@ -1,12 +1,15 @@
 import backoff from '../backoff'
 
 describe('backoff', () => {
+  const delay = 1000
+  const currentTime = 1234.234 // ms since "origin time"; for testing purposes, greater than initial delay
+  jest.spyOn(performance, 'now').mockImplementation(() => currentTime)
   jest.useFakeTimers()
 
   test('executes the first call immediately', () => {
     // expected delays: 0, 200, 400, 800, ...
-    const mockCallback = jest.fn(() => { /* noop */})
-    const backedOff = backoff(100, 2, mockCallback)
+    const mockCallback = jest.fn()
+    const backedOff = backoff(delay, 2, mockCallback)
 
     backedOff()
     expect(mockCallback).toHaveBeenCalledTimes(1)
@@ -14,30 +17,40 @@ describe('backoff', () => {
   })
 
   test('debounces repeated calls', () => {
-    const mockCallback = jest.fn(() => { /* noop */})
-    const backedOff = backoff(100, 2, mockCallback)
+    const mockCallback = jest.fn()
+    const backedOff = backoff(delay, 2, mockCallback)
     backedOff()
 
     for (let i = 0; i < 10; i++) {
       backedOff()
     }
     expect(mockCallback).toHaveBeenCalledTimes(1)
-    jest.advanceTimersByTime(1000)
+    jest.advanceTimersByTime(delay * 2 + 1)
     expect(mockCallback).toHaveBeenCalledTimes(2)
+  })
+
+  test('passes on arguments', () => {
+    const mockCallback = jest.fn()
+    const backedOff = backoff(delay, 2, mockCallback)
+    backedOff('a', 'b', 'c')
+
+    expect(mockCallback).toHaveBeenCalledWith('a', 'b', 'c')
   })
 
   test('multiplies delay by factor', () => {
     // expected delays: 0, 2000, 4000, 8000, ...
-    const mockCallback = jest.fn(() => { /* noop */})
-    const backedOff = backoff(1000, 2, mockCallback)
+    const mockCallback = jest.fn()
+
+    const backedOff = backoff(delay, 2, mockCallback)
     backedOff()
+    expect(mockCallback).toHaveBeenCalled()
 
     const expectedDelays = [2000, 4000, 8000]
     expectedDelays.forEach((ms, index) => {
       backedOff()
       jest.advanceTimersByTime(ms - 100)
       expect(mockCallback).toHaveBeenCalledTimes(index + 1)
-      jest.advanceTimersByTime(100)
+      jest.advanceTimersByTime(150)
       expect(mockCallback).toHaveBeenCalledTimes(index + 2)
     });
   })
@@ -47,7 +60,7 @@ describe('backoff', () => {
     const callback = () => {
       x++
     }
-    const backedOff = backoff(1000, 2, callback)
+    const backedOff = backoff(delay, 2, callback)
     backedOff()
     expect(x).toBe(1)
 
@@ -64,7 +77,7 @@ describe('backoff', () => {
       }
     }
     const obj = new Obj()
-    const backedOff = backoff(1000, 2, obj.callback)
+    const backedOff = backoff(delay, 2, obj.callback)
     backedOff()
     expect(obj.x).toBe(1)
 

--- a/src/ui/shared/round/__tests__/backoff.test.ts
+++ b/src/ui/shared/round/__tests__/backoff.test.ts
@@ -1,0 +1,75 @@
+import backoff from '../backoff'
+
+describe('backoff', () => {
+  jest.useFakeTimers()
+
+  test('executes the first call immediately', () => {
+    // expected delays: 0, 200, 400, 800, ...
+    const mockCallback = jest.fn(() => { /* noop */})
+    const backedOff = backoff(100, 2, mockCallback)
+
+    backedOff()
+    expect(mockCallback).toHaveBeenCalledTimes(1)
+    expect(setTimeout).toHaveBeenCalledTimes(0)
+  })
+
+  test('debounces repeated calls', () => {
+    const mockCallback = jest.fn(() => { /* noop */})
+    const backedOff = backoff(100, 2, mockCallback)
+    backedOff()
+
+    for (let i = 0; i < 10; i++) {
+      backedOff()
+    }
+    expect(mockCallback).toHaveBeenCalledTimes(1)
+    jest.advanceTimersByTime(1000)
+    expect(mockCallback).toHaveBeenCalledTimes(2)
+  })
+
+  test('multiplies delay by factor', () => {
+    // expected delays: 0, 2000, 4000, 8000, ...
+    const mockCallback = jest.fn(() => { /* noop */})
+    const backedOff = backoff(1000, 2, mockCallback)
+    backedOff()
+
+    const expectedDelays = [2000, 4000, 8000]
+    expectedDelays.forEach((ms, index) => {
+      backedOff()
+      jest.advanceTimersByTime(ms - 100)
+      expect(mockCallback).toHaveBeenCalledTimes(index + 1)
+      jest.advanceTimersByTime(100)
+      expect(mockCallback).toHaveBeenCalledTimes(index + 2)
+    });
+  })
+
+  test('works with arrow functions', () => {
+    let x = 0
+    const callback = () => {
+      x++
+    }
+    const backedOff = backoff(1000, 2, callback)
+    backedOff()
+    expect(x).toBe(1)
+
+    backedOff()
+    jest.runAllTimers()
+    expect(x).toBe(2)
+  })
+
+  test('works with object methods', () => {
+    class Obj {
+      x = 0
+      callback = () => {
+        this.x++
+      }
+    }
+    const obj = new Obj()
+    const backedOff = backoff(1000, 2, obj.callback)
+    backedOff()
+    expect(obj.x).toBe(1)
+
+    backedOff()
+    jest.runAllTimers()
+    expect(obj.x).toBe(2)
+  })
+})

--- a/src/ui/shared/round/backoff.ts
+++ b/src/ui/shared/round/backoff.ts
@@ -1,16 +1,16 @@
-type Callback = (...args: any[]) => void
-export default function backoff(delay: number, factor: number, callback: Callback): Callback {
+type Callback<T> = (...args: T[]) => void
+export default function backoff<T>(delay: number, factor: number, callback: Callback<T>): Callback<T> {
   let timer: number | undefined
   let lastExec = 0
 
-  return (...args: any[]): void => {
+  return (...args: T[]): void => {
     const elapsed = performance.now() - lastExec
 
     const exec = () => {
       timer = undefined
       lastExec = performance.now()
       delay *= factor
-      callback(args)
+      callback(...args)
     }
 
     if (timer) clearTimeout(timer)

--- a/src/ui/shared/round/backoff.ts
+++ b/src/ui/shared/round/backoff.ts
@@ -1,0 +1,21 @@
+type Callback = (...args: any[]) => void
+export default function backoff(delay: number, factor: number, callback: Callback): Callback {
+  let timer: number | undefined
+  let lastExec = 0
+
+  return (...args: any[]): void => {
+    const elapsed = performance.now() - lastExec
+
+    const exec = () => {
+      timer = undefined
+      lastExec = performance.now()
+      delay *= factor
+      callback(args)
+    }
+
+    if (timer) clearTimeout(timer)
+
+    if (elapsed > delay) exec()
+    else timer = setTimeout(exec, delay - elapsed)
+  }
+}

--- a/src/ui/shared/round/clock/clockView.ts
+++ b/src/ui/shared/round/clock/clockView.ts
@@ -47,7 +47,7 @@ export default {
 
 const sepHigh = ':'
 const sepLow = ' '
-export function formatClockTime(time: Millis, showTenths: boolean, isRunning: boolean = false): string {
+export function formatClockTime(time: Millis, showTenths: boolean, isRunning = false): string {
   const date = new Date(time)
   const millis = date.getUTCMilliseconds()
   const minutes = pad2(date.getUTCMinutes())

--- a/src/ui/shared/round/ground.ts
+++ b/src/ui/shared/round/ground.ts
@@ -8,7 +8,7 @@ import settings from '../../../settings'
 import { boardOrientation } from '../../../utils'
 import * as chessFormat from '../../../utils/chessFormat'
 
-function makeConfig(data: OnlineGameData, fen: string, flip: boolean = false): cg.InitConfig {
+function makeConfig(data: OnlineGameData, fen: string, flip = false): cg.InitConfig {
   const lastStep = data.steps[data.steps.length - 1]
   const lastMove = data.game.lastMove ?
     chessFormat.uciToMove(data.game.lastMove) :

--- a/src/ui/shared/round/socket.ts
+++ b/src/ui/shared/round/socket.ts
@@ -10,6 +10,7 @@ import redraw from '../../../utils/redraw'
 import sound from '../../../sound'
 import vibrate from '../../../vibrate'
 import OnlineRound from './OnlineRound'
+import backoff from './backoff'
 
 export default class RoundSocket {
 
@@ -136,34 +137,11 @@ export default class RoundSocket {
     this.iface.send('moretime')
   }, 300)
 
-  public outoftime =  backoff(500, 1.1, () => {
+  public outoftime = backoff(500, 1.1, () => {
     this.iface.send('flag', this.ctrl.data.game.player)
   })
 
   public berserk = throttle(() => {
     this.iface.send('berserk', null, { ackable: true })
   }, 200)
-}
-
-type Callback = (...args: any[]) => void
-function backoff(delay: number, factor: number, callback: Callback): Callback {
-  let timer: number | undefined
-  let lastExec = 0
-
-  return function(this: any, ...args: any[]): void {
-    const self: any = this
-    const elapsed = performance.now() - lastExec
-
-    function exec() {
-      timer = undefined
-      lastExec = performance.now()
-      delay *= factor
-      callback.apply(self, args)
-    }
-
-    if (timer) clearTimeout(timer)
-
-    if (elapsed > delay) exec()
-    else timer = setTimeout(exec, delay - elapsed)
-  }
 }

--- a/src/ui/shared/round/view/roundView.tsx
+++ b/src/ui/shared/round/view/roundView.tsx
@@ -184,7 +184,7 @@ function renderHeader(ctrl: OnlineRound) {
     children = [
       backButton([
         renderTitle(ctrl),
-        bookmarkButton(ctrl.toggleBookmark, ctrl.data.bookmarked!!),
+        bookmarkButton(ctrl.toggleBookmark, ctrl.data.bookmarked!),
       ])
     ]
   } else {
@@ -279,8 +279,8 @@ function renderSubmitMovePopup(ctrl: OnlineRound) {
 function userInfos(user: User, player: Player, playerName: string) {
   let title: string
   if (user) {
-    let onlineStatus = user.online ? 'connected to lichess' : 'offline'
-    let onGameStatus = player.onGame ? 'currently on this game' : 'currently not on this game'
+    const onlineStatus = user.online ? 'connected to lichess' : 'offline'
+    const onGameStatus = player.onGame ? 'currently on this game' : 'currently not on this game'
     title = `${playerName}: ${onlineStatus}; ${onGameStatus}`
   } else {
     title = playerName
@@ -290,7 +290,7 @@ function userInfos(user: User, player: Player, playerName: string) {
 
 function renderPlayerName(player: Player) {
   if (player.name || player.username || player.user) {
-    let name = player.name || player.username || player.user?.username
+    const name = player.name || player.username || player.user?.username
     return h('span', [
       player.user?.title ? [
         h('span.userTitle' + (player.user?.title === 'BOT' ? '.bot' : ''), player.user.title),
@@ -390,7 +390,7 @@ function renderPlayTable(
   return (
     <section className={classN + ' ' + position}>
       {renderAntagonistInfo(ctrl, player, material, position, isCrazy)}
-      { !!step.crazy ?
+      { step.crazy ?
         h(CrazyPocket, {
           ctrl,
           crazyData: step.crazy,

--- a/src/ui/shared/sideMenu/SideMenuCtrl.ts
+++ b/src/ui/shared/sideMenu/SideMenuCtrl.ts
@@ -7,7 +7,7 @@ import { BACKDROP_OPACITY } from '.'
 export type Side = 'left' | 'right'
 
 export default class SideMenuCtrl {
-  public isOpen: boolean = false
+  public isOpen = false
   public readonly side: Side
 
   private readonly menuID: string

--- a/src/ui/shared/svgboard/index.ts
+++ b/src/ui/shared/svgboard/index.ts
@@ -8,7 +8,7 @@ export function makeBoard(fen: string, orientation: Color) {
   const pieces = cgFen.read(fen)
   let b = '<svg xmlns="http://www.w3.org/2000/svg" width="360" height="360">'
   for (const [k, p] of pieces) {
-    let pos = pos2px(orient(key2pos(k), orientation))
+    const pos = pos2px(orient(key2pos(k), orientation))
     b += makePiece(pos, p)
   }
   b += '</svg>'

--- a/src/ui/shared/tree/index.ts
+++ b/src/ui/shared/tree/index.ts
@@ -1,6 +1,6 @@
 import { build, TreeWrapper } from './tree'
 import * as path from './path'
 import * as ops from './ops'
-import { Tree } from './interfaces'
+import * as Tree from './interfaces'
 
 export { build, TreeWrapper, path, ops, Tree }

--- a/src/ui/shared/tree/interfaces.ts
+++ b/src/ui/shared/tree/interfaces.ts
@@ -1,108 +1,106 @@
 import { Pockets } from '../../../lichess/interfaces/game'
 import { Shape as BrushShape } from '../BoardBrush'
 
-export namespace Tree {
-  export type Path = string
+export type Path = string
 
-  export interface ClientEval {
-    fen: string
-    maxDepth?: number
-    depth: number
-    knps?: number
-    nodes: number
-    millis?: number
-    pvs: PvData[]
-    cloud?: boolean
-    cp?: number
-    mate?: number
-    retried?: boolean
-    // maybe not keep here
-    best?: Uci
-  }
-
-  export interface ServerEval {
-    cp?: number
-    mate?: number
-    best?: Uci
-  }
-
-  export interface PvData {
-    readonly moves: ReadonlyArray<string>
-    mate?: number
-    cp?: number
-  }
-
-  export interface Node {
-    readonly id: string
-    readonly ply: Ply
-    readonly fen: Fen
-    readonly uci?: Uci
-    readonly san?: San
-    children: Node[]
-    comments?: Comment[]
-    dests?: DestsMap
-    drops?: string | ReadonlyArray<string> | undefined | null
-    readonly check?: boolean
-    threat?: ClientEval
-    ceval?: ClientEval
-    eval?: ServerEval
-    tbhit?: TablebaseHit | null
-    opening?: Opening | null
-    glyphs?: Glyph[]
-    clock?: Clock
-    parentClock?: Clock
-    shapes?: ReadonlyArray<Shape>
-    readonly comp?: boolean
-    threefold?: boolean
-    readonly fail?: boolean
-    puzzle?: string
-    // added locally during analysis by chess worker
-    checkCount?: { white: number, black: number }
-    readonly pgnMoves?: ReadonlyArray<string>
-    player?: Color
-    end?: boolean
-    crazyhouse?: {
-      readonly pockets: Pockets
-    }
-    // added locally by study gamebook ctrl
-    gamebook?: Gamebook
-  }
-
-  export interface TablebaseHit {
-    winner: Color | undefined
-    best?: Uci
-  }
-
-  export interface Gamebook {
-    deviation?: string
-    hint?: string
-    shapes?: Shape[]
-  }
-
-  export interface Comment {
-    readonly id: string
-    readonly by: string | {
-      readonly id: string
-      readonly name: string
-    }
-    text: string
-  }
-
-  export interface Opening {
-    readonly name: string
-    readonly eco: string
-  }
-
-  export interface Glyph {
-    readonly name: string
-    readonly symbol: string
-  }
-
-  export type Clock = number
-
-  export type Shape = BrushShape
+export interface ClientEval {
+  fen: string
+  maxDepth?: number
+  depth: number
+  knps?: number
+  nodes: number
+  millis?: number
+  pvs: PvData[]
+  cloud?: boolean
+  cp?: number
+  mate?: number
+  retried?: boolean
+  // maybe not keep here
+  best?: Uci
 }
 
-export function isClientEval(ev: Tree.ServerEval | Tree.ClientEval): ev is Tree.ClientEval {
-  return (ev as Tree.ClientEval).depth !== undefined
+export interface ServerEval {
+  cp?: number
+  mate?: number
+  best?: Uci
+}
+
+export interface PvData {
+  readonly moves: ReadonlyArray<string>
+  mate?: number
+  cp?: number
+}
+
+export interface Node {
+  readonly id: string
+  readonly ply: Ply
+  readonly fen: Fen
+  readonly uci?: Uci
+  readonly san?: San
+  children: Node[]
+  comments?: Comment[]
+  dests?: DestsMap
+  drops?: string | ReadonlyArray<string> | undefined | null
+  readonly check?: boolean
+  threat?: ClientEval
+  ceval?: ClientEval
+  eval?: ServerEval
+  tbhit?: TablebaseHit | null
+  opening?: Opening | null
+  glyphs?: Glyph[]
+  clock?: Clock
+  parentClock?: Clock
+  shapes?: ReadonlyArray<Shape>
+  readonly comp?: boolean
+  threefold?: boolean
+  readonly fail?: boolean
+  puzzle?: string
+  // added locally during analysis by chess worker
+  checkCount?: { white: number, black: number }
+  readonly pgnMoves?: ReadonlyArray<string>
+  player?: Color
+  end?: boolean
+  crazyhouse?: {
+    readonly pockets: Pockets
+  }
+  // added locally by study gamebook ctrl
+  gamebook?: Gamebook
+}
+
+export interface TablebaseHit {
+  winner: Color | undefined
+  best?: Uci
+}
+
+export interface Gamebook {
+  deviation?: string
+  hint?: string
+  shapes?: Shape[]
+}
+
+export interface Comment {
+  readonly id: string
+  readonly by: string | {
+    readonly id: string
+    readonly name: string
+  }
+  text: string
+}
+
+export interface Opening {
+  readonly name: string
+  readonly eco: string
+}
+
+export interface Glyph {
+  readonly name: string
+  readonly symbol: string
+}
+
+export type Clock = number
+
+export type Shape = BrushShape
+
+export function isClientEval(ev: ServerEval | ClientEval): ev is ClientEval {
+  return (ev as ClientEval).depth !== undefined
 }

--- a/src/ui/shared/tree/ops.ts
+++ b/src/ui/shared/tree/ops.ts
@@ -46,7 +46,7 @@ export function nodeAtPly(nodeList: Tree.Node[], ply: number): Tree.Node | undef
 
 export function takePathWhile(nodeList: Tree.Node[], predicate: (node: Tree.Node) => boolean): Tree.Path {
   let path = ''
-  for (let i in nodeList) {
+  for (const i in nodeList) {
     if (predicate(nodeList[i])) path += nodeList[i].id
     else break
   }

--- a/src/ui/shared/tree/ops.ts
+++ b/src/ui/shared/tree/ops.ts
@@ -1,4 +1,4 @@
-import { Tree } from './interfaces'
+import * as Tree from './interfaces'
 import { Pockets } from '../../../lichess/interfaces/game'
 
 function mainlineChild(node: Tree.Node): Tree.Node | undefined {

--- a/src/ui/shared/tree/ops.ts
+++ b/src/ui/shared/tree/ops.ts
@@ -20,8 +20,9 @@ export function findInMainline(fromNode: Tree.Node, predicate: (node: Tree.Node)
 
 // returns a list of nodes collected from the original one
 export function collect(fromNode: Tree.Node, pickChild: (node: Tree.Node) => Tree.Node | undefined): Tree.Node[] {
-  let nodes = [fromNode], n = fromNode, c
-  while (c = pickChild(n)) {
+  const nodes = [fromNode]
+  let n = fromNode, c
+  while ((c = pickChild(n))) {
     nodes.push(c)
     n = c
   }

--- a/src/ui/shared/tree/path.ts
+++ b/src/ui/shared/tree/path.ts
@@ -28,7 +28,7 @@ export function contains(p1: Tree.Path, p2: Tree.Path): boolean {
 
 export function fromNodeList(nodes: ReadonlyArray<Tree.Node>): Tree.Path {
   let path = ''
-  for (let i in nodes) {
+  for (const i in nodes) {
     path += nodes[i].id
   }
   return path

--- a/src/ui/shared/tree/path.ts
+++ b/src/ui/shared/tree/path.ts
@@ -1,4 +1,4 @@
-import { Tree } from './interfaces'
+import * as Tree from './interfaces'
 
 export const root: Tree.Path = ''
 

--- a/src/ui/shared/tree/tree.ts
+++ b/src/ui/shared/tree/tree.ts
@@ -70,7 +70,7 @@ export function build(root: Tree.Node): TreeWrapper {
 
   function getCurrentNodesAfterPly(nodeList: Tree.Node[], mainline: Tree.Node[], ply: number): Tree.Node[] {
     let node, nodes = []
-    for (let i in nodeList) {
+    for (const i in nodeList) {
       node = nodeList[i]
       if (node.ply <= ply && mainline[i].id !== node.id) break
       if (node.ply > ply) nodes.push(node)

--- a/src/ui/shared/tree/tree.ts
+++ b/src/ui/shared/tree/tree.ts
@@ -1,6 +1,6 @@
 import * as treePath from './path'
 import * as ops from './ops'
-import { Tree } from './interfaces'
+import * as Tree from './interfaces'
 
 export type MaybeNode = Tree.Node | undefined
 

--- a/src/ui/shared/tree/tree.ts
+++ b/src/ui/shared/tree/tree.ts
@@ -69,9 +69,9 @@ export function build(root: Tree.Node): TreeWrapper {
   }
 
   function getCurrentNodesAfterPly(nodeList: Tree.Node[], mainline: Tree.Node[], ply: number): Tree.Node[] {
-    let node, nodes = []
+    const nodes = []
     for (const i in nodeList) {
-      node = nodeList[i]
+      const node = nodeList[i]
       if (node.ply <= ply && mainline[i].id !== node.id) break
       if (node.ply > ply) nodes.push(node)
     }

--- a/src/ui/study/StudyIndexCtrl.ts
+++ b/src/ui/study/StudyIndexCtrl.ts
@@ -27,7 +27,7 @@ export default class StudyIndexCtrl {
 
   private cacheAvailable: boolean
   // used to restore scroll position only once from cached state
-  private initialized: boolean = false
+  private initialized = false
 
   public constructor(
     public readonly cat: PagerCategory = 'all',

--- a/src/ui/study/studyIndexView.ts
+++ b/src/ui/study/studyIndexView.ts
@@ -151,4 +151,4 @@ const Item = {
 } as Mithril.Component<{
   study: PagerDataWithDate
   index: number
-}, {}>
+}>

--- a/src/ui/teams/TeamsListCtrl.ts
+++ b/src/ui/teams/TeamsListCtrl.ts
@@ -37,7 +37,7 @@ export default class TeamsListCtrl {
   }
 
   public onTabChange = (tabIndex: number) => {
-    const loc = window.location.search.replace(/\?tab\=\w+$/, '')
+    const loc = window.location.search.replace(/\?tab=\w+$/, '')
     try {
       window.history.replaceState(window.history.state, '', loc + '?tab=' + tabIndex)
     } catch (e) { console.error(e) }

--- a/src/ui/teams/TeamsListCtrl.ts
+++ b/src/ui/teams/TeamsListCtrl.ts
@@ -9,7 +9,7 @@ import session from '../../session'
 export default class TeamsListCtrl {
   public currentTab: number
 
-  public isSearchOpen: boolean = false
+  public isSearchOpen = false
   public searchResults?: TeamResults
 
   public allTeams?: TeamResults

--- a/src/ui/timeline.tsx
+++ b/src/ui/timeline.tsx
@@ -44,7 +44,7 @@ export default {
       }, this.timeline().map(renderTimelineEntry))
     ])
   }
-} as Mithril.Component<{}, State>
+} as Mithril.Component<Record<string, never>, State>
 
 export function timelineOnTap(e: Event) {
   const el = helper.getLI(e)

--- a/src/ui/tournament/TournamentsListCtrl.ts
+++ b/src/ui/tournament/TournamentsListCtrl.ts
@@ -32,7 +32,7 @@ export default class TournamentsListCtrl {
   }
 
   onTabChange = (tabIndex: number) => {
-    const loc = window.location.search.replace(/\?tab\=\w+$/, '')
+    const loc = window.location.search.replace(/\?tab=\w+$/, '')
     try {
       window.history.replaceState(window.history.state, '', loc + '?tab=' + tabIndex)
     } catch (e) { console.error(e) }

--- a/src/ui/tournament/detail/TournamentCtrl.ts
+++ b/src/ui/tournament/detail/TournamentCtrl.ts
@@ -25,11 +25,11 @@ interface PagesCache {
 export default class TournamentCtrl {
   public id: string
   public tournament: Tournament
-  public page: number = 1
+  public page = 1
   public currentPageResults!: ReadonlyArray<StandingPlayer>
-  public hasJoined: boolean = false
-  public focusOnMe: boolean = false
-  public isLoadingPage: boolean = false
+  public hasJoined = false
+  public focusOnMe = false
+  public isLoadingPage = false
   public startsAt?: string
 
   public readonly chat?: Chat

--- a/src/ui/tournament/detail/tournamentDetail.ts
+++ b/src/ui/tournament/detail/tournamentDetail.ts
@@ -63,9 +63,7 @@ export default {
     }
 
     const tournament = this.ctrl.tournament
-    let header: Mithril.Children
-
-    header = headerWidget(null,
+    const header = headerWidget(null,
       backButton(h('div.main_header_title.withSub', [
         h('h1', [
           h('span.fa.fa-trophy'),

--- a/src/ui/tournament/tournamentXhr.ts
+++ b/src/ui/tournament/tournamentXhr.ts
@@ -1,6 +1,8 @@
 import { fetchJSON } from '../../http'
 import { Tournament, PlayerInfo, TournamentCreateResponse, TournamentLists, StandingPage } from '../../lichess/interfaces/tournament'
 
+type EmptyObject = Record<string, never>
+
 export function currentTournaments(): Promise<TournamentLists> {
   return fetchJSON('/tournament', {}, true)
 }
@@ -21,7 +23,7 @@ export function loadPage(id: string, p: number): Promise<StandingPage> {
   return fetchJSON('/tournament/' + id + '/standing/' + p)
 }
 
-export function join(id: string, password?: string, team?: string): Promise<{}> {
+export function join(id: string, password?: string, team?: string): Promise<EmptyObject> {
   return fetchJSON('/tournament/' + id + '/join',
   {
     method: 'POST',
@@ -32,7 +34,7 @@ export function join(id: string, password?: string, team?: string): Promise<{}> 
   }, true)
 }
 
-export function withdraw(id: string): Promise<{}> {
+export function withdraw(id: string): Promise<EmptyObject> {
   return fetchJSON('/tournament/' + id + '/withdraw', { method: 'POST' }, true)
 }
 

--- a/src/ui/user/account/clock.ts
+++ b/src/ui/user/account/clock.ts
@@ -16,7 +16,7 @@ export default {
       h('ul.native_scroller.page.settings_list.game', render(prefsCtrl))
     )
   }
-} as Mithril.Component<{}, {}>
+} as Mithril.Component
 
 export const prefsCtrl = {
   clockTenths: session.lichessBackedProp<number>('prefs.clockTenths', ClockTenths.LOWTIME),

--- a/src/ui/user/account/gameBehavior.ts
+++ b/src/ui/user/account/gameBehavior.ts
@@ -16,7 +16,7 @@ export default {
       h('ul.native_scroller.page.settings_list.game', render(prefsCtrl))
     )
   }
-} as Mithril.Component<{}, {}>
+} as Mithril.Component
 
 export const prefsCtrl = {
   premove: session.lichessBackedProp<boolean>('prefs.premove', true),
@@ -37,7 +37,7 @@ export function render(ctrl: typeof prefsCtrl) {
       i18n('promoteToQueenAutomatically'), AutoQueenChoices, ctrl.autoQueen
     )),
     h('li.list_item', formWidgets.renderMultipleChoiceButton(
-      i18n('claimDrawOnThreefoldRepetitionAutomatically').replace(/\%s/g, ''), AutoThreefoldChoices, ctrl.autoThreefold
+      i18n('claimDrawOnThreefoldRepetitionAutomatically').replace(/%s/g, ''), AutoThreefoldChoices, ctrl.autoThreefold
     )),
     h('li.list_item', formWidgets.renderMultipleChoiceButton(
       i18n('moveConfirmation'), SubmitMoveChoices, ctrl.submitMove

--- a/src/ui/user/account/gameDisplay.ts
+++ b/src/ui/user/account/gameDisplay.ts
@@ -16,7 +16,7 @@ export default {
       h('ul.native_scroller.page.settings_list.game', render(prefsCtrl))
     )
   }
-} as Mithril.Component<{}, {}>
+} as Mithril.Component
 
 const prefsCtrl = {
   animation: session.lichessBackedProp<number>('prefs.animation', Animation.NORMAL),

--- a/src/ui/user/account/kid.ts
+++ b/src/ui/user/account/kid.ts
@@ -21,7 +21,7 @@ export default {
     const header = dropShadowHeader(null, backButton(i18n('kidMode')))
     return layout.free(header, renderBody(this))
   }
-} as Mithril.Component<{}, { submitting: boolean }>
+} as Mithril.Component<Record<string, never>, { submitting: boolean }>
 
 function renderBody(ctrl: { submitting: boolean }) {
   return [

--- a/src/ui/user/account/preferences.ts
+++ b/src/ui/user/account/preferences.ts
@@ -28,7 +28,7 @@ function renderBody() {
   ]
 }
 
-const PreferencesScreen: Mithril.Component<{}, {}> = {
+const PreferencesScreen: Mithril.Component = {
   oncreate: helper.viewSlideIn,
 
   oninit() {

--- a/src/ui/user/account/privacy.ts
+++ b/src/ui/user/account/privacy.ts
@@ -28,7 +28,7 @@ export default {
     const header = dropShadowHeader(null, backButton(i18n('privacy')))
     return layout.free(header, renderBody(ctrl))
   }
-} as Mithril.Component<{}, { ctrl: Ctrl }>
+} as Mithril.Component<Record<string, never>, { ctrl: Ctrl }>
 
 function renderBody(ctrl: Ctrl) {
   return [

--- a/src/ui/user/games/UserGamesCtrl.ts
+++ b/src/ui/user/games/UserGamesCtrl.ts
@@ -84,7 +84,7 @@ export default function UserGamesCtrl(userId: string, filter?: string): IUserGam
   const loadUserAndFilters = (userData: UserFullProfile) => {
     scrollState.user = userData
     const f = Object.keys(userData.count)
-    .filter(k => filters.hasOwnProperty(k) && (k === 'all' || userData.count[k] > 0))
+    .filter(k => Object.prototype.hasOwnProperty.call(filters, k) && (k === 'all' || userData.count[k] > 0))
     .map(k => {
       return {
         key: <GameFilter>k,

--- a/src/ui/user/games/games.ts
+++ b/src/ui/user/games/games.ts
@@ -33,7 +33,7 @@ const UserGames: Mithril.Component<Attrs, State> = {
 
     const user = this.ctrl.scrollState.user
     const displayedTitle = user ?
-      userTitle(user.online!!, user.patron!!, user.username, user.title) :
+      userTitle(user.online!, user.patron!, user.username, user.title) :
       userTitle(false, Boolean(patron), username || id, title)
 
     const header = headerWidget(null, backButton(displayedTitle))

--- a/src/ui/user/related/RelatedCtrl.ts
+++ b/src/ui/user/related/RelatedCtrl.ts
@@ -9,7 +9,7 @@ import challengeForm from '../../challengeForm'
 export default class RelatedCtrl {
   currentTab: number
 
-  isLoadingNextPage: boolean = false
+  isLoadingNextPage = false
 
   followers?: readonly Related[]
   followersPaginator?: Paginator<Related>

--- a/src/ui/user/related/RelatedCtrl.ts
+++ b/src/ui/user/related/RelatedCtrl.ts
@@ -47,7 +47,7 @@ export default class RelatedCtrl {
   }
 
   public onTabChange = (tabIndex: number) => {
-    const loc = window.location.search.replace(/\?tab\=\w+$/, '')
+    const loc = window.location.search.replace(/\?tab=\w+$/, '')
     try {
       window.history.replaceState(window.history.state, '', loc + '?tab=' + tabIndex)
     } catch (e) { console.error(e) }

--- a/src/ui/user/userView.tsx
+++ b/src/ui/user/userView.tsx
@@ -14,7 +14,7 @@ import session from '../../session'
 import { IUserCtrl, ProfileUser, isFullUser } from './UserCtrl'
 
 export function header(user: ProfileUser, ctrl: IUserCtrl) {
-  const title = userTitle(user.online!!, user.patron!!, user.username, user.title)
+  const title = userTitle(user.online!, user.patron!, user.username, user.title)
 
   const backButton = !ctrl.isMe() ? renderBackbutton(title) : null
   return dropShadowHeader(backButton ? null : title, backButton)

--- a/src/utils/Gesture.ts
+++ b/src/utils/Gesture.ts
@@ -40,7 +40,7 @@ export default class Gesture {
 
   private swipeThresholdX: number
   private swipeThresholdY: number
-  private startInputTimestamp: number = 0
+  private startInputTimestamp = 0
 
   constructor (
     readonly element: HTMLElement,

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -37,7 +37,7 @@ function linkReplace(match: string, before: string, url: string) {
 
 const userPattern = /(^|[^\w@#/])@([\w-]{2,})/g
 
-function userLinkReplace(orig: string, prefix: String, user: string) {
+function userLinkReplace(orig: string, prefix: string, user: string) {
   if (user.length > 20) return orig
   return prefix + `<a href="?/@/${user}">@${user}</a>`
 }

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -3,9 +3,9 @@
 const rAmp = /&/g
 const rLt = /</g
 const rGt = />/g
-const rApos = /\'/g
-const rQuot = /\"/g
-const hChars = /[&<>\"\']/
+const rApos = /'/g
+const rQuot = /"/g
+const hChars = /[&<>"']/
 export function escapeHtml(str: string) {
   if (hChars.test(String(str))) {
     return str
@@ -26,7 +26,7 @@ export function linkify(text: string): string {
   return linked
 }
 
-const linkPattern = /(^|[\s\n]|<[A-Za-z]*\/?>)((?:(?:https?):\/\/|lichess\.org\/)[\-A-Z0-9+\u0026\u2019@#\/%?=()~_|!:,.;]*[\-A-Z0-9+\u0026@#\/%=~()_|])/gi
+const linkPattern = /(^|[\s\n]|<[A-Za-z]*\/?>)((?:(?:https?):\/\/|lichess\.org\/)[-A-Z0-9+\u0026\u2019@#/%?=()~_|!:,.;]*[-A-Z0-9+\u0026@#/%=~()_|])/gi
 
 function linkReplace(match: string, before: string, url: string) {
   if (url.indexOf('&quot;') !== -1) return match

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -152,7 +152,7 @@ export function serializeQueryParameters(obj: StringMap): string {
   return str
 }
 
-export function noop() {}
+export function noop() { /* noop */ }
 
 const perfIconsMap: {[index: string]: string} = {
   bullet: 'T',

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -34,14 +34,13 @@ export function shallowEqual(objA: OAny, objB: OAny): boolean {
   return true
 }
 
-export function getAtPath(obj: Object, path: string): any {
+export function getAtPath(obj: Record<string, any>, path: string): any {
   return path.split('.').reduce((acc: any, x) => acc && acc[x], obj)
 }
 
 export function setAtPath(obj: any, path: any, value: any): void {
   if (typeof path === 'string') {
-    /* tslint:disable-next-line:no-var-keyword */
-    var path: any = path.split('.')
+    path = path.split('.')
   }
 
   if (path.length > 1) {

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -45,7 +45,7 @@ export function setAtPath(obj: any, path: any, value: any): void {
   }
 
   if (path.length > 1) {
-    let p = path.shift()
+    const p = path.shift()
     if (obj[p] === null || typeof obj[p] !== 'object') {
       obj[p] = {}
     }

--- a/src/utils/querystring.ts
+++ b/src/utils/querystring.ts
@@ -25,7 +25,7 @@ export function buildQueryString(obj: any, sep?: string, eq?: string, name?: str
 
   if (typeof obj === 'object') {
     return Object.keys(obj).map((k) => {
-      let ks = encodeURIComponent(stringifyPrimitive(k)) + eq
+      const ks = encodeURIComponent(stringifyPrimitive(k)) + eq
       if (Array.isArray(obj[k])) {
         return obj[k].map((v: any) => {
           return ks + encodeURIComponent(stringifyPrimitive(v))

--- a/src/utils/sleep.ts
+++ b/src/utils/sleep.ts
@@ -37,7 +37,7 @@ function idleTimer(delay: number, onIdle: () => void, onWakeUp: () => void): () 
   let listening = false
   let active = true
   let lastSeenActive = Date.now()
-  let intervalID: number
+  let intervalID: number | undefined = undefined
   const onActivity = () => {
     if (!active) {
       // console.log('Wake up')

--- a/src/utils/zanimo/index.js
+++ b/src/utils/zanimo/index.js
@@ -78,7 +78,7 @@ function applycss(el, attr, value) {
 }
 
 function css(el, attr, value) {
-  if(el._zanimo && el._zanimo.hasOwnProperty(attr)) {
+  if(el._zanimo && Object.prototype.hasOwnProperty.call(el._zanimo, attr)) {
     console.warn(
       'Zanimo transition with transform=' +
         el._zanimo[attr].value +

--- a/src/xhr.ts
+++ b/src/xhr.ts
@@ -201,7 +201,7 @@ export function setServerLang(lang: string): Promise<void> {
         lang
       })
     })
-    .then(() => {})
+    .then(() => { /* noop */ })
   } else {
     return Promise.resolve()
   }


### PR DESCRIPTION
Closes #1467.

The linters can be configured to have different warnings levels, enforced styles, or can be disabled completely. If you'd like to see what linters raised errors initially, check out 
cf26093 and run `npx eslint src/ --quiet`.

Lastly, there are still tons of warnings, which don't currently cause linting to fail but will appear in `npm run lint` output and should be incrementally addressed in the future.