### PR TITLE
Use withoutNNUE flavor by default

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -29,6 +29,7 @@ android {
     flavorDimensions 'nnue'
     productFlavors {
         withoutNNUE {
+            isDefault true
             dimension 'nnue'
         }
         withNNUE {


### PR DESCRIPTION
Make the Android "withoutNNUE" flavor the default which makes building simpler and is probably what newcomers to the project want.
I tried it out, and after this fix "withoutNNUDebug" was selected when I created a new Android Studio project:
<img width="723" alt="Screenshot 2021-01-30 at 21 38 36" src="https://user-images.githubusercontent.com/845979/106367704-c640e600-6344-11eb-8a35-f4c27289c498.png">