### PR TITLE
Show announcements

### DIFF
--- a/src/announce.ts
+++ b/src/announce.ts
@@ -1,0 +1,19 @@
+export interface Announcement {
+  msg: string
+  date: string
+}
+
+let announce: Announcement | undefined
+
+export function get(): Announcement | undefined {
+  return announce
+}
+
+export function set(a: Announcement | undefined): void {
+  announce = a
+}
+
+export default {
+  get,
+  set,
+}

--- a/src/announce.ts
+++ b/src/announce.ts
@@ -14,7 +14,14 @@ function keyOf(a: Announcement): string {
   return a.date // includes milliseconds, effectively unique
 }
 
+function isExpired(dateStr: string): boolean {
+  return new Date(dateStr) < new Date()
+}
+
 export function get(): Announcement | undefined {
+  if (announce && isExpired(announce.date)) {
+    announce = undefined
+  }
   return announce
 }
 
@@ -43,7 +50,7 @@ export async function dismiss(): Promise<void> {
 
   // clean up existing dismissed cache and add this new entry
   const existingDismissed = await asyncStorage.get<string[]>(STORAGE_KEY)
-  const newDismissed = (existingDismissed || []).filter(dateStr => (new Date(dateStr) >= new Date()))
+  const newDismissed = (existingDismissed || []).filter(dateStr => !isExpired(dateStr))
   newDismissed.push(dismissKey)
   await asyncStorage.set(STORAGE_KEY, newDismissed)
 

--- a/src/announce.ts
+++ b/src/announce.ts
@@ -1,4 +1,7 @@
+import asyncStorage from './asyncStorage'
 import redraw from './utils/redraw'
+
+const STORAGE_KEY = 'announce'
 
 export interface Announcement {
   msg: string
@@ -7,16 +10,47 @@ export interface Announcement {
 
 let announce: Announcement | undefined
 
+function keyOf(a: Announcement): string {
+  return a.date // includes milliseconds, effectively unique
+}
+
 export function get(): Announcement | undefined {
   return announce
 }
 
-export function set(a: Announcement | undefined): void {
+export async function set(a?: Announcement): Promise<void> {
+  if (a) {
+    const newKey = keyOf(a)
+    const existing = await asyncStorage.get<string[]>(STORAGE_KEY)
+    if (existing?.includes(newKey)) {
+      // previously dismissed, no-op
+      return
+    }
+  }
   announce = a
   redraw()
+}
+
+export async function dismiss(): Promise<void> {
+  if (announce === undefined) {
+    return
+  }
+  const dismissKey = keyOf(announce)
+
+  // clear the announcement
+  announce = undefined
+  redraw()
+
+  // clean up existing dismissed cache and add this new entry
+  const existingDismissed = await asyncStorage.get<string[]>(STORAGE_KEY)
+  const newDismissed = (existingDismissed || []).filter(dateStr => (new Date(dateStr) >= new Date()))
+  newDismissed.push(dismissKey)
+  await asyncStorage.set(STORAGE_KEY, newDismissed)
+
 }
 
 export default {
   get,
   set,
+  dismiss,
 }

--- a/src/announce.ts
+++ b/src/announce.ts
@@ -1,3 +1,5 @@
+import redraw from './utils/redraw'
+
 export interface Announcement {
   msg: string
   date: string
@@ -11,6 +13,7 @@ export function get(): Announcement | undefined {
 
 export function set(a: Announcement | undefined): void {
   announce = a
+  redraw()
 }
 
 export default {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -4,6 +4,7 @@ import formatDistanceStrict from 'date-fns/esm/formatDistanceStrict'
 import formatRelative from 'date-fns/esm/formatRelative'
 import addSeconds from 'date-fns/esm/addSeconds'
 import settings from './settings'
+import formatDistanceToNowStrict from 'date-fns/esm/formatDistanceToNowStrict'
 
 type Quantity = 'zero' | 'one' | 'two' | 'few' | 'many' | 'other'
 
@@ -53,7 +54,7 @@ function format(message: string, ...args: Array<string | number>): string {
 }
 
 function formatVdom(str: string, ...args: Array<Mithril.Child>): Mithril.Children {
-  const segments: Array<any> = str.split(/(%(?:\d\$)?s)/g)
+  const segments: Array<Mithril.Child> = str.split(/(%(?:\d\$)?s)/g)
   for (let i = 1; i <= args.length; i++) {
     const pos = segments.indexOf('%' + i + '$s')
     if (pos !== -1) segments[pos] = args[i - 1]
@@ -90,6 +91,13 @@ export function formatDuration(duration: Seconds): string {
 export function fromNow(date: Date): string {
   return formatRelative(date, new Date(), {
     locale: dateLocale
+  })
+}
+
+export function distanceToNowStrict(date: Date, addSuffix = false): string {
+  return formatDistanceToNowStrict(date, {
+    locale: dateLocale,
+    addSuffix: addSuffix,
   })
 }
 

--- a/src/socket.ts
+++ b/src/socket.ts
@@ -13,6 +13,7 @@ import friendsApi, { Friend } from './lichess/friends'
 import challengesApi from './lichess/challenges'
 import { ChallengesData } from './lichess/interfaces/challenge'
 import session from './session'
+import announce, { Announcement } from './announce'
 
 export interface LichessMessage<T> {
   t: string
@@ -107,6 +108,14 @@ const defaultHandlers: MessageHandlers = {
   resync() {
     router.reload()
   },
+  announce: (a: Announcement | Record<string, never>) => {
+    const announcement = a as Announcement
+    if (announcement.date) {
+      announce.set(announcement)
+    } else {
+      announce.set(undefined)
+    }
+  }
 }
 
 function handleFollowingOnline(data: string[], payload: FollowingOnlinePayload) {

--- a/src/styl/main.styl
+++ b/src/styl/main.styl
@@ -8,7 +8,12 @@ body
   padding-top: env(safe-area-inset-top);
 
 .announce
-  padding 2px 10px 
+  position absolute
+  top 0
+  min-height headerHeight
+  width 100%
+  padding env(safe-area-inset-top) 10px
+  box-sizing border-box
   background orange
   text-align center
   color white
@@ -16,10 +21,22 @@ body
   flex-flow row nowrap
   justify-content space-between
   align-items center
+  z-index 1000
+
+  .text
+    overflow hidden
+    text-overflow ellipsis
+    white-space nowrap
 
   .dismiss
     margin-right 0
     margin-left 0.5em
+
+  &.expanded
+    height auto
+    .text
+      overflow auto
+      white-space normal
 
 #free_content
   background-color bgdarkPage

--- a/src/styl/main.styl
+++ b/src/styl/main.styl
@@ -7,6 +7,16 @@ body
   overflow hidden
   padding-top: env(safe-area-inset-top);
 
+.announce
+  padding 2px 10px 
+  background orange
+  text-align center
+  color white
+  display flex
+  flex-flow row nowrap
+  justify-content space-between
+  align-items center
+
 #free_content
   background-color bgdarkPage
   .list_item

--- a/src/styl/main.styl
+++ b/src/styl/main.styl
@@ -17,6 +17,10 @@ body
   justify-content space-between
   align-items center
 
+  .dismiss
+    margin-right 0
+    margin-left 0.5em
+
 #free_content
   background-color bgdarkPage
   .list_item

--- a/src/ui/announceView.ts
+++ b/src/ui/announceView.ts
@@ -1,0 +1,29 @@
+import h from 'mithril/hyperscript'
+import announce, { Announcement } from '~/announce'
+import { distanceToNowStrict } from '~/i18n'
+import { prop } from '~/utils'
+import redraw from '~/utils/redraw'
+import { ontap } from './helper'
+
+const expanded = prop(false)
+
+export default function renderAnnouncement(announcement?: Announcement): Mithril.Child {
+  if (!announcement) {
+    return null
+  }
+
+  return h('div.announce', {
+    className: expanded() ? 'expanded' : '',
+  }, [
+    h('span.text', {
+      oncreate: ontap(() => {
+        expanded(!expanded())
+        redraw()
+      })
+    }, announcement.msg),
+    h('span', distanceToNowStrict(new Date(announcement.date), true)),
+    h('span.fa.fa-times.dismiss', {
+      oncreate: ontap(announce.dismiss)
+    })
+  ])
+}

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -15,6 +15,8 @@ import friendsPopup from './friendsPopup'
 import lobby from './lobby'
 import EdgeOpenHandler, { Handlers } from './shared/sideMenu/EdgeOpenHandler'
 import MainBoard from './shared/layout/MainBoard'
+import announce, { Announcement } from '~/announce'
+import { distanceToNowStrict } from '~/i18n'
 
 let background: string
 
@@ -59,11 +61,13 @@ export default {
     footer?: Mithril.Children,
     overlay?: Mithril.Children,
     scrollListener?: (e: Event) => void
-  ) {
+  ): Mithril.Vnode {
     background = background || settings.general.theme.background()
+    const announcement = announce.get()
     return h('div.view-container', containerOpts(background), [
       h('main#page', { oncreate: handleMenuOpen }, [
         h('header.main_header', header),
+        renderAnnouncement(announcement),
         h('div#free_content.content.native_scroller', {
           className: footer ? 'withFooter' : '',
           oncreate: ({ dom }) => {
@@ -119,4 +123,15 @@ function containerOpts(bgTheme: string) {
   return {
     className: bgClass(bgTheme)
   }
+}
+
+function renderAnnouncement(announcement?: Announcement): Mithril.Child {
+  if (!announcement) {
+    return null
+  }
+
+  return h('div.announce', [
+    h('span', announcement.msg),
+    h('span', distanceToNowStrict(new Date(announcement.date), true))
+  ])
 }

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -2,7 +2,7 @@ import { Capacitor } from '@capacitor/core'
 import h from 'mithril/hyperscript'
 import settings from '../settings'
 import Gesture from '../utils/Gesture'
-import { ontap, viewportDim } from './helper'
+import { viewportDim } from './helper'
 import * as menu from './menu'
 import MenuView from './menu/menuView'
 import gamesMenu from './gamesMenu'
@@ -15,8 +15,8 @@ import friendsPopup from './friendsPopup'
 import lobby from './lobby'
 import EdgeOpenHandler, { Handlers } from './shared/sideMenu/EdgeOpenHandler'
 import MainBoard from './shared/layout/MainBoard'
-import announce, { Announcement } from '~/announce'
-import { distanceToNowStrict } from '~/i18n'
+import renderAnnouncement from './announceView'
+import announce from '~/announce'
 
 let background: string
 
@@ -63,11 +63,10 @@ export default {
     scrollListener?: (e: Event) => void
   ): Mithril.Vnode {
     background = background || settings.general.theme.background()
-    const announcement = announce.get()
     return h('div.view-container', containerOpts(background), [
       h('main#page', { oncreate: handleMenuOpen }, [
         h('header.main_header', header),
-        renderAnnouncement(announcement),
+        renderAnnouncement(announce.get()),
         h('div#free_content.content.native_scroller', {
           className: footer ? 'withFooter' : '',
           oncreate: ({ dom }) => {
@@ -123,18 +122,4 @@ function containerOpts(bgTheme: string) {
   return {
     className: bgClass(bgTheme)
   }
-}
-
-function renderAnnouncement(announcement?: Announcement): Mithril.Child {
-  if (!announcement) {
-    return null
-  }
-
-  return h('div.announce', [
-    h('span', announcement.msg),
-    h('span', distanceToNowStrict(new Date(announcement.date), true)),
-    h('span.fa.fa-times.dismiss', {
-      oncreate: ontap(announce.dismiss)
-    })
-  ])
 }

--- a/src/ui/layout.ts
+++ b/src/ui/layout.ts
@@ -2,7 +2,7 @@ import { Capacitor } from '@capacitor/core'
 import h from 'mithril/hyperscript'
 import settings from '../settings'
 import Gesture from '../utils/Gesture'
-import { viewportDim } from './helper'
+import { ontap, viewportDim } from './helper'
 import * as menu from './menu'
 import MenuView from './menu/menuView'
 import gamesMenu from './gamesMenu'
@@ -132,6 +132,9 @@ function renderAnnouncement(announcement?: Announcement): Mithril.Child {
 
   return h('div.announce', [
     h('span', announcement.msg),
-    h('span', distanceToNowStrict(new Date(announcement.date), true))
+    h('span', distanceToNowStrict(new Date(announcement.date), true)),
+    h('span.fa.fa-times.dismiss', {
+      oncreate: ontap(announce.dismiss)
+    })
   ])
 }

--- a/src/ui/shared/layout/MainBoard.ts
+++ b/src/ui/shared/layout/MainBoard.ts
@@ -1,4 +1,6 @@
 import h from 'mithril/hyperscript'
+import announce from '~/announce'
+import renderAnnouncement from '~/ui/announceView'
 
 import Gesture from '../../../utils/Gesture'
 import { viewportDim } from '../../helper'
@@ -45,6 +47,7 @@ export default {
       className: color,
     }, [
       h('header.main_header.board', header),
+      renderAnnouncement(announce.get()),
       h('div.content_round', {
         className: attrs.klass || ''
       }, children),


### PR DESCRIPTION
Part of https://github.com/veloce/lichobile/issues/1539 .

This does not include:
- real-time `announce` message handling on websockets
- announcements for logged-out users

but hopefully this sets up a good foundation for those things later.

Note that this only affects "free" layouts - so e.g. online rounds and analysis layouts don't show any announcements. Is this desirable?

<img src="https://user-images.githubusercontent.com/569991/108575513-77a1be80-72e8-11eb-89e9-30c6623e93a7.png" width="300" />
<img src="https://user-images.githubusercontent.com/569991/108575512-77a1be80-72e8-11eb-8c6a-72f65ceaeb6c.png" width="300" />
<img src="https://user-images.githubusercontent.com/569991/108575510-77092800-72e8-11eb-94a3-9551b791bdc3.png" width="300" />
