### PR TITLE
Tweak challenge card

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -352,7 +352,6 @@ const untranslated: StringMap = {
   lichessIsUnreachable: 'lichess.org is unreachable.',
   mustSignInToJoin: 'You must sign in to join it.',
   playerisInvitingYou: '%s is inviting you',
-  toATypeGame: 'To a %s game',
   unsupportedVariant: 'Variant %s is not supported in this version',
   notesSynchronizationHasFailed: 'Notes synchronization with lichess has failed, please try later.',
   returnToHome: 'Return to home',

--- a/src/styl/games-menu.styl
+++ b/src/styl/games-menu.styl
@@ -145,8 +145,9 @@
     margin-top 10px
     text-transform none
     color #fff
-  .variantName
-    margin-right 5px
+  .time-indication
+    &:before
+      vertical-align bottom
   .actions
     height 45px
     background #aa8f58

--- a/src/ui/gamesMenu.ts
+++ b/src/ui/gamesMenu.ts
@@ -189,7 +189,6 @@ function renderIncomingChallenge(c: Challenge) {
   }
 
   const mode = c.rated ? i18n('rated') : i18n('casual')
-  const timeAndMode = challengesApi.challengeTime(c) + ', ' + mode
   const mark = c.challenger.provisional ? '?' : ''
   const playerName = `${c.challenger.id} (${c.challenger.rating}${mark})`
 
@@ -202,8 +201,11 @@ function renderIncomingChallenge(c: Challenge) {
       h('div.description', [
         h('h2.title', i18n('playerisInvitingYou', playerName)),
         h('p.variant', [
-          h('span.variantName', i18n('toATypeGame', c.variant.name)),
-          h('span.time-indication[data-icon=p]', timeAndMode)
+          h('span.time-indication[data-icon=p]', challengesApi.challengeTime(c)),
+          ' • ',
+          h('span.variantName', c.variant.name),
+          ' • ',
+          h('span', mode),
         ])
       ]),
       h('div.actions', [
@@ -227,7 +229,6 @@ function renderIncomingChallenge(c: Challenge) {
 function renderSendingChallenge(c: Challenge) {
 
   const mode = c.rated ? i18n('rated') : i18n('casual')
-  const timeAndMode = challengesApi.challengeTime(c) + ', ' + mode
 
   function playerName(destUser: ChallengeUser) {
     const mark = destUser.provisional ? '?' : ''
@@ -243,8 +244,11 @@ function renderSendingChallenge(c: Challenge) {
       h('div.description', [
         h('h2.title', c.destUser ? playerName(c.destUser) : 'Open challenge'),
         h('p.variant', [
-          h('span.variantName', i18n('toATypeGame', c.variant.name)),
-          h('span.time-indication[data-icon=p]', timeAndMode)
+          h('span.time-indication[data-icon=p]', challengesApi.challengeTime(c)),
+          ' • ',
+          h('span.variantName', c.variant.name),
+          ' • ',
+          h('span', mode),
         ]),
       ]),
       h('div.actions', [


### PR DESCRIPTION
To remove `toATypeGame` i18n key, as mentioned in https://github.com/veloce/lichobile/pull/1601#discussion_r598081391. Ordering (time - variant - rating mode) is consistent with the quick-pairing overlay:
![Screen Shot 2021-03-20 at 11 15 21 AM](https://user-images.githubusercontent.com/569991/111874944-9e95f380-896d-11eb-884e-e51d298231ae.png)

## Before
<img src="https://user-images.githubusercontent.com/569991/111874846-51b21d00-896d-11eb-9b0b-684603ae98f5.png" width="300">
<img src="https://user-images.githubusercontent.com/569991/111874848-524ab380-896d-11eb-83c6-8a387716c600.png" width="300">

## After
<img src="https://user-images.githubusercontent.com/569991/111874864-62fb2980-896d-11eb-85d1-1337a6569277.png" width="300">
<img src="https://user-images.githubusercontent.com/569991/111874865-62fb2980-896d-11eb-9945-c560892fcbd0.png" width="300">