### PR TITLE
Set check when receiving castle move from API

### DIFF
--- a/src/ui/shared/round/OnlineRound.ts
+++ b/src/ui/shared/round/OnlineRound.ts
@@ -396,7 +396,7 @@ export default class OnlineRound implements OnlineRoundInterface {
     }
   }
 
-  public apiMove(o: MoveOrDrop) {
+  public apiMove(o: MoveOrDrop): void {
     const d = this.data
     const playing = gameApi.isPlayerPlaying(d)
 
@@ -501,6 +501,10 @@ export default class OnlineRound implements OnlineRoundInterface {
           chessFormat.uciToDropPos(o.uci),
           newConf
         )
+      }
+
+      if (o.check) {
+        this.chessground.setCheck(true)
       }
 
       if (o.promotion) {


### PR DESCRIPTION
Currently, when applying a move from the server, we [handle castles differently](https://github.com/veloce/lichobile/blob/c1c28216880984bad756a35a2b50381299a4dfd1/src/ui/shared/round/OnlineRound.ts#L483-L494) than other moves. This causes us to drop the `check` property when applying castles.

This PR fixes that by always applying the `check` property, regardless of whether the move is a castle or not. Closes #1605.

**Note**: as shown in the video below, this does _not_ cause the red check aura to appear when the move is applied locally (in this case, before move confirmation) - only when it comes from the server. This is currently the case whether the checking move is a castle or not. Users with high latency may continue to experience check aura appearance lag.

https://user-images.githubusercontent.com/569991/111905944-9d73cd80-8a24-11eb-936e-0528d9fa76cf.mov