### PR TITLE
Fix OTB advantage icon orientation

### DIFF
--- a/src/styl/chessground-piece.styl
+++ b/src/styl/chessground-piece.styl
@@ -1,8 +1,3 @@
-.mode_facing.opponent piece,
-#page.white .mode_flip.turn_black piece,
-#page.black .mode_flip.turn_white piece
-  transform rotate(180deg)
-
 /* Merida */
 .merida piece
   &.pawn


### PR DESCRIPTION
The entire offline play table was rotated 180, but the icons inside were also flipped 180. Removed the latter style to close #1617.

Tested the following modes with advantages on each side:
- offline vs. AI
- OTB with "flip pieces and opponent info after move" enabled
- OTB without the above setting enabled