### PR TITLE
Option to choose board side in landscape mode

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -136,6 +136,7 @@ export default {
     pieceMove: prop<'tap' | 'drag' | 'both'>('game.pieceMove', 'both'),
     rookCastle: prop<0 | 1>('game.rookCastle', 1),
     moveList: prop<boolean>('game.moveList', true),
+    landscapeBoardSide: prop<'right' | 'left'>('game.landscapeBoardSide', 'left'),
   },
 
   analyse: {

--- a/src/styl/board-content.styl
+++ b/src/styl/board-content.styl
@@ -16,6 +16,9 @@
     display flex
     flex-flow row nowrap
 
+    &.righty
+      flex-direction row-reverse
+
 .playable_board_wrapper, .board_wrapper
   flex-shrink 0
   flex-grow 0

--- a/src/ui/settings/gameDisplay.ts
+++ b/src/ui/settings/gameDisplay.ts
@@ -39,6 +39,15 @@ function renderBody() {
       ),
       h('li.list_item',
         formWidgets.renderMultipleChoiceButton(
+          i18n('landscapeBoardSide'), [
+            { label: 'Left', value: 'left' },
+            { label: 'Right', value: 'right' },
+          ],
+          settings.game.landscapeBoardSide,
+        ),
+      ),
+      h('li.list_item',
+        formWidgets.renderMultipleChoiceButton(
           i18n('pgnPieceNotation'), [
             { label: i18n('chessPieceSymbol'), value: true },
             { label: i18n('pgnLetter'), value: false },

--- a/src/ui/shared/layout/MainBoard.ts
+++ b/src/ui/shared/layout/MainBoard.ts
@@ -1,9 +1,10 @@
 import h from 'mithril/hyperscript'
 import announce from '~/announce'
+import settings from '~/settings'
 import renderAnnouncement from '~/ui/announceView'
 
 import Gesture from '../../../utils/Gesture'
-import { viewportDim } from '../../helper'
+import { classSet, viewportDim } from '../../helper'
 import * as menu from '../../menu'
 import EdgeOpenHandler, { Handlers } from '../sideMenu/EdgeOpenHandler'
 
@@ -43,13 +44,20 @@ export default {
 
   view({ attrs, children }) {
     const { header, color } = attrs
+    const classes = {
+      righty: settings.game.landscapeBoardSide() === 'right'
+    } as {[k: string]: boolean}
+    if (attrs.klass) {
+      classes[attrs.klass] = true
+    }
+
     return h('main#page', {
       className: color,
     }, [
       h('header.main_header.board', header),
       renderAnnouncement(announce.get()),
       h('div.content_round', {
-        className: attrs.klass || ''
+        className: classSet(classes),
       }, children),
       h('div#menu-close-overlay.menu-backdrop', { oncreate: menu.backdropCloseHandler })
     ])

--- a/translation/source/mobile-misc.yaml
+++ b/translation/source/mobile-misc.yaml
@@ -6,3 +6,4 @@ en:
   notesSynchronizationHasFailed: "Notes synchronization with lichess has failed, please try later."
   vibrateOnGameEvents: "Vibrate on game events"
   offline: "Offline"
+  landscapeBoardSide: "Board screen side (in landscape mode)" # Side of the screen the board appears on in analysis or online rounds when the device is in landscape mode.

--- a/www/i18n/en-US.js
+++ b/www/i18n/en-US.js
@@ -1096,5 +1096,6 @@ export default {
   "solved": "solved",
   "failed": "failed",
   "playedXTimes:one": "Played %s time",
-  "playedXTimes:other": "Played %s times"
+  "playedXTimes:other": "Played %s times",
+  "landscapeBoardSide": "Board screen side (in landscape mode)"
 }


### PR DESCRIPTION
Closes #1353. Closes #1541.

The setting:
<img src="https://user-images.githubusercontent.com/569991/113203425-08e64800-923a-11eb-8ff0-08923deda013.png" width="400">


Offline round:
<img src="https://user-images.githubusercontent.com/569991/113203223-c15fbc00-9239-11eb-9709-bae4ba098ebd.png" width="400">

Analysis:
<img src="https://user-images.githubusercontent.com/569991/113203224-c15fbc00-9239-11eb-9e92-3f72571d4a9b.png" width="400">

Online round:
<img src="https://user-images.githubusercontent.com/569991/113203225-c15fbc00-9239-11eb-8319-259a0ecd20c8.png" width="400">
