### PR TITLE
Get training ctrl piece theme directly from settings

### DIFF
--- a/src/ui/training/TrainingCtrl.ts
+++ b/src/ui/training/TrainingCtrl.ts
@@ -12,7 +12,6 @@ import * as chess from '../../chess'
 import * as chessFormat from '../../utils/chessFormat'
 import session from '../../session'
 import sound from '../../sound'
-import settings from '../../settings'
 import { PuzzleData } from '../../lichess/interfaces/training'
 import promotion from '../shared/offlineRound/promotion'
 import { PromotingInterface } from '../shared/round'
@@ -43,15 +42,12 @@ export default class TrainingCtrl implements PromotingInterface {
 
   vm!: VM
 
-  pieceTheme: string
-
   private tree!: TreeWrapper
   private initialData!: PuzzleData
 
   constructor(cfg: PuzzleData, database: Database) {
     this.menu = menu.controller(this)
     this.database = database
-    this.pieceTheme = settings.general.theme.piece()
 
     this.init(cfg)
 

--- a/src/ui/training/trainingView.ts
+++ b/src/ui/training/trainingView.ts
@@ -100,7 +100,7 @@ function renderFeedback(ctrl: TrainingCtrl) {
       return h('div.training-explanation', [
         h('div.player', [
           h('div.piece-no-square', {
-            className: ctrl.pieceTheme
+            className: settings.general.theme.piece(),
           }, h('piece.king.' + ctrl.data.puzzle.color)),
           h('div.training-instruction', [
             h('strong', i18n('yourTurn')),


### PR DESCRIPTION
Closes #1650. I imagine the TrainingCtrl was being reused, so its piece theme wasn't getting updated. This is more similar to how the Board view gets the piece theme (it's considered part of the view state, not the controller state).