### PR TITLE
Messages: replace instead of push state to match web

### DIFF
--- a/src/ui/msg/MsgCtrl.ts
+++ b/src/ui/msg/MsgCtrl.ts
@@ -40,7 +40,7 @@ export default class MsgCtrl {
       this.search.result = undefined
       this.loading = false
       if (data.convo) {
-        router.History.pushState(`/inbox/${data.convo.user.name}`)
+        router.History.replaceState(undefined, `/inbox/${data.convo.user.name}`)
         this.onLoadConvo(data.convo)
         redraw()
       }
@@ -52,7 +52,6 @@ export default class MsgCtrl {
 
   showSide = (): void => {
     this.pane = 'side'
-    router.History.pushState('/inbox')
     redraw()
   }
 
@@ -170,8 +169,8 @@ export default class MsgCtrl {
       this.data = data
       this.confirmDelete = null
       this.pane = 'side'
+      router.History.replaceState(undefined, '/inbox')
       redraw()
-      router.History.pushState('/inbox')
     })
   }
 


### PR DESCRIPTION
May fix #1659. The mobile app used `History.pushState` where the website used `History.replaceState`, which made it difficult to navigate out of chat using the native back button after opening conversations many times.

After this PR, the messages behavior will be as follows:
- When opening a conversation, the current history entry, `/inbox`, will be replaced with the conversation path (`/inbox/<userId>`).  
- When navigating back to the inbox via the back arrow, the history entry will not be replaced (that is, the URL will reflect the specific conversation that was just closed).

This means that at any point in the messages UI, hitting the native "back" button will exit the messages UI entirely. I don't love this behavior, but 1) it matches the website and 2) I see no way to avoid it without relying on `history.back()`, which would cause an unnecessary XHR reload of the inbox.

Tested locally using Chrome.