### PR TITLE
Fix piece color for past best move when promo

### DIFF
--- a/src/chessground/util.ts
+++ b/src/chessground/util.ts
@@ -74,7 +74,7 @@ export const allKeys: readonly Key[] =
 
 export const invKeys: readonly Key[] = allKeys.slice(0).reverse()
 
-export function opposite(color: Color) {
+export function opposite(color: Color): Color {
   return color === 'white' ? 'black' : 'white'
 }
 

--- a/src/ui/analyse/view/boardView.ts
+++ b/src/ui/analyse/view/boardView.ts
@@ -8,6 +8,7 @@ import { Shape } from '../../shared/BoardBrush'
 import Clock from './Clock'
 import { povDiff } from '../ceval/winningChances'
 import AnalyseCtrl from '../AnalyseCtrl'
+import { opposite } from '~/chessground/util'
 
 export default function renderBoard(ctrl: AnalyseCtrl) {
   return h('div.analyse-boardWrapper', [
@@ -88,7 +89,7 @@ function computeShapes(ctrl: AnalyseCtrl): readonly Shape[] {
       })
     }
     if (rEval && rEval.best) {
-      pastBestShape = moveOrDropShape(rEval.best, 'paleGreen', player)
+      pastBestShape = moveOrDropShape(rEval.best, 'paleGreen', opposite(player))
     }
   }
 


### PR DESCRIPTION
Closes #1676.

Tested with a local client against [the game mentioned](https://lichess.org/9sVANEDz/black#79) in the issue.

I also tried to test against a [random bughouse game](https://lichess.org/Jf7wjgRf/black#19) to verify drop move suggestions are rendered as expected. However, it appears the server doesn't provide best move suggestions for drops, which is when this code path would be exercised.