### PR TITLE
Fix black bars visible on Android devices with narrow aspect ratios

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        android:resizeableActivity="false">
+        android:resizeableActivity="true">
 
         <meta-data android:name="firebase_analytics_collection_deactivated" android:value="true" />
         <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />


### PR DESCRIPTION
This fixes black bars visible at the top and bottom of the screen on some devices (like Samsung S8, etc.), as mentioned in #1145 and #1416.

If the `android:resizeableActivity` flag was set to `false` on purpose for some reason, we can also set the [minimum aspect ratio](https://developer.android.com/guide/practices/screens-distribution#MaxAspectRatio) instead to 2.1.

Also, the `android:resizeableActivity` flag can be removed altogether now, as it is true by default.