### PR TITLE
Update board orientation on color selection

### DIFF
--- a/src/ui/coordinates/CoordCtrl.ts
+++ b/src/ui/coordinates/CoordCtrl.ts
@@ -34,7 +34,7 @@ export default class CoordCtrl {
   started = false
 
   constructor() {
-    this.orientation = 'white'
+    this.orientation = this.getOrientation(settings.coordinates.colorChoice())
     this.chessground = new Chessground({
       fen: INITIAL_FEN,
       orientation: this.orientation,
@@ -59,6 +59,16 @@ export default class CoordCtrl {
 
   public getOrientation(color: Color | 'random'): Color {
     return color === 'random' ? randomColor() : color as Color
+  }
+
+  public updateOrientation() {
+    if (!this.started) {
+      this.orientation = this.getOrientation(settings.coordinates.colorChoice())
+      this.chessground.set({
+        orientation: this.orientation
+      })
+      redraw()
+    }  
   }
 
   private nextCoord(): Key {
@@ -103,11 +113,6 @@ export default class CoordCtrl {
       this.score = 0
       this.wrongAnswer = false
       this.tempWrong = false
-      this.orientation = this.getOrientation(settings.coordinates.colorChoice())
-
-      this.chessground.set({
-        orientation: this.orientation
-      })
 
       const startedAt = performance.now()
       const frame = () => {

--- a/src/ui/coordinates/coordView.ts
+++ b/src/ui/coordinates/coordView.ts
@@ -56,7 +56,10 @@ export default function view(ctrl: CoordCtrl): Mithril.Children {
           return h('i.action_bar_button.' + o, {
             className: o === store.colorChoice() ? 'selected' : '',
             oncreate: helper.ontap(() => {
-              store.colorChoice(o as Color | 'random')
+              if (!ctrl.started) {
+                store.colorChoice(o as Color | 'random')
+                ctrl.updateOrientation()
+              }
             })
           })
         })


### PR DESCRIPTION
In order to align behavior with the website, I changed the coordinates training such that the board orientation already changes on selecting a color, even before training is started. 
This also means a random color is automatically selected on tap and on initialization.
Also color selection is prevented when training is in progress.  
