### PR TITLE
Push instead of replace path when going to analysis

### DIFF
--- a/src/ui/shared/round/OnlineRound.ts
+++ b/src/ui/shared/round/OnlineRound.ts
@@ -74,8 +74,6 @@ export default class OnlineRound implements OnlineRoundInterface {
   private clockIntervId!: number
   private blur: boolean
 
-  private readonly playableOnInit: boolean
-
   private transientMove: TransientMove
   private appStateListener: PluginListenerHandle
 
@@ -93,8 +91,6 @@ export default class OnlineRound implements OnlineRoundInterface {
 
     this.zenModeEnabled = settings.game.zenMode()
     this.blur = false
-
-    this.playableOnInit = gameApi.isPlayerPlaying(this.data)
 
     this.vm = {
       ply: this.lastPly(),
@@ -184,7 +180,7 @@ export default class OnlineRound implements OnlineRoundInterface {
 
   public goToAnalysis = () => {
     const d = this.data
-    router.set(`/analyse/online/${d.game.id}/${boardOrientation(d)}?ply=${this.vm.ply}&curFen=${d.game.fen}`, !this.playableOnInit)
+    router.set(`/analyse/online/${d.game.id}/${boardOrientation(d)}?ply=${this.vm.ply}&curFen=${d.game.fen}`)
   }
 
   public openUserPopup = (position: string, userId: string) => {


### PR DESCRIPTION
Currently, the user can navigate back to the game round view from a _playable_ game by pressing the back arrow or the native back button; however, from a _non-playable_ game, the only way to do the same is via the back arrow. Both states should allow the use of the native back button to navigate back.

This `replace` parameter looks left over from a WIP commit from 2 years ago, so do correct me if I'm missing some more context here 🙂 

Closes #1758.