### PR TITLE
Fix last-move theme special casing

### DIFF
--- a/src/styl/chessground.styl
+++ b/src/styl/chessground.styl
@@ -23,9 +23,9 @@ square
       background radial-gradient(transparent 0%,transparent 80%,rgba(20,30,85,0.3) 80%)
   &.last-move
     background-color rgba(155, 199, 0, 0.41)
-  .green > .cg-board > &.last-move,
-  .green-plastic > .cg-board > &.last-move,
-  .marble > .cg-board > &.last-move
+  .board-green .cg-board > &.last-move,
+  .board-green-plastic .cg-board > &.last-move,
+  .board-marble .cg-board > &.last-move
     background-color: rgba(0, 155, 199, 0.41)
   &.check
     background radial-gradient(ellipse at center, rgba(255, 0, 0, 1) 0%, rgba(231, 0, 0, 1) 25%, rgba(169, 0, 0, 0) 89%, rgba(158, 0, 0, 0) 100%)


### PR DESCRIPTION
We prepend the board theme name with `board-` when constructing class names for the board element. Closes #1752.