### PR TITLE
Restore time indicator for anonymous analysis

### DIFF
--- a/src/ui/analyse/view/boardView.ts
+++ b/src/ui/analyse/view/boardView.ts
@@ -25,9 +25,9 @@ export default function renderBoard(ctrl: AnalyseCtrl) {
   ])
 }
 
-export function playerBar(ctrl: AnalyseCtrl, color: Color) {
+export function playerBar(ctrl: AnalyseCtrl, color: Color): Mithril.Child {
   const pName = ctrl.playerName(color)
-  if (pName === 'Anonymous') return null
+  const isAnonymous = pName === 'Anonymous'
 
   const study = ctrl.study && ctrl.study.data
   let title, elo, result: string | undefined
@@ -44,7 +44,7 @@ export function playerBar(ctrl: AnalyseCtrl, color: Color) {
   return h('div.analyse-player_bar', {
     className: ctrl.settings.s.smallBoard ? 'halfsize' : ''
   }, [
-    h('div.info', [
+    h('div.info', isAnonymous ? null : [
       result ? h('span.result', result) : null,
       h('span.name', (title ? title + ' ' : '') + pName + (elo ? ` (${elo})` : '')),
     ]),


### PR DESCRIPTION
Closes #1759. Note the username and score (1, 0, ½) are not included for anonymous players.

Verified locally that time data for any game is available to both registered and unregistered/guest/anonymous users, i.e. the analysis board will look the same for both.

https://user-images.githubusercontent.com/569991/125720491-aa64eaf9-ecff-4e63-afc2-6613dd1d6a12.mov

