### PR TITLE
Type custom plugins

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,6 +7,6 @@
   "rules": {
     "semi": "off",
     "quotes": ["error", "single", { "avoidEscape": true }],
-    "eqeqeq": ["error", "always"]
+    "eqeqeq": ["error", "smart"]
   }
 }

--- a/src/dts/plugins.d.ts
+++ b/src/dts/plugins.d.ts
@@ -1,0 +1,7 @@
+import { SoundEffectPlugin } from 'capacitor-sound-effect';
+
+declare module '@capacitor/core' {
+  interface PluginRegistry {
+    SoundEffect: SoundEffectPlugin
+  }
+}

--- a/src/dts/plugins.d.ts
+++ b/src/dts/plugins.d.ts
@@ -1,12 +1,17 @@
-import { SoundEffectPlugin } from 'capacitor-sound-effect';
+import { SoundEffectPlugin } from 'capacitor-sound-effect'
 
 declare module '@capacitor/core' {
   interface PluginRegistry {
     Badge: BadgePlugin
+    CPUInfo: CPUInfoPlugin
     SoundEffect: SoundEffectPlugin
   }
 }
 
 interface BadgePlugin {
   setNumber: (opts: {badge: number}) => Promise<void>
+}
+
+interface CPUInfoPlugin {
+  nbCores: () => Promise<{value: number}>
 }

--- a/src/dts/plugins.d.ts
+++ b/src/dts/plugins.d.ts
@@ -4,6 +4,7 @@ declare module '@capacitor/core' {
   interface PluginRegistry {
     Badge: BadgePlugin
     CPUInfo: CPUInfoPlugin
+    LiShare: LiSharePlugin
     LiToast: LiToastPlugin
     SoundEffect: SoundEffectPlugin
   }
@@ -15,6 +16,12 @@ interface BadgePlugin {
 
 interface CPUInfoPlugin {
   nbCores: () => Promise<{value: number}>
+}
+
+type ShareOptions = ({url: string} | {text: string}) & {title?: string}
+
+interface LiSharePlugin {
+  share: (opts: ShareOptions) => Promise<void>
 }
 
 type ToastOptions = {

--- a/src/dts/plugins.d.ts
+++ b/src/dts/plugins.d.ts
@@ -4,6 +4,7 @@ declare module '@capacitor/core' {
   interface PluginRegistry {
     Badge: BadgePlugin
     CPUInfo: CPUInfoPlugin
+    LiBuildConfig: LiBuildConfigPlugin
     LiShare: LiSharePlugin
     LiToast: LiToastPlugin
     SoundEffect: SoundEffectPlugin
@@ -16,6 +17,10 @@ interface BadgePlugin {
 
 interface CPUInfoPlugin {
   nbCores: () => Promise<{value: number}>
+}
+
+interface LiBuildConfigPlugin {
+  get: () => Promise<BuildConfig>
 }
 
 type ShareOptions = ({url: string} | {text: string}) & {title?: string}

--- a/src/dts/plugins.d.ts
+++ b/src/dts/plugins.d.ts
@@ -2,6 +2,11 @@ import { SoundEffectPlugin } from 'capacitor-sound-effect';
 
 declare module '@capacitor/core' {
   interface PluginRegistry {
+    Badge: BadgePlugin
     SoundEffect: SoundEffectPlugin
   }
+}
+
+interface BadgePlugin {
+  setNumber: (opts: {badge: number}) => Promise<void>
 }

--- a/src/dts/plugins.d.ts
+++ b/src/dts/plugins.d.ts
@@ -1,9 +1,11 @@
+import { KeepAwakePlugin } from '@capacitor-community/keep-awake'
 import { SoundEffectPlugin } from 'capacitor-sound-effect'
 
 declare module '@capacitor/core' {
   interface PluginRegistry {
     Badge: BadgePlugin
     CPUInfo: CPUInfoPlugin
+    KeepAwake: KeepAwakePlugin
     LiBuildConfig: LiBuildConfigPlugin
     LiShare: LiSharePlugin
     LiToast: LiToastPlugin

--- a/src/dts/plugins.d.ts
+++ b/src/dts/plugins.d.ts
@@ -4,6 +4,7 @@ declare module '@capacitor/core' {
   interface PluginRegistry {
     Badge: BadgePlugin
     CPUInfo: CPUInfoPlugin
+    LiToast: LiToastPlugin
     SoundEffect: SoundEffectPlugin
   }
 }
@@ -14,4 +15,14 @@ interface BadgePlugin {
 
 interface CPUInfoPlugin {
   nbCores: () => Promise<{value: number}>
+}
+
+type ToastOptions = {
+  text: string
+  duration?: 'short' | 'long'
+  position?: 'top' | 'center' | 'bottom'
+}
+
+interface LiToastPlugin {
+  show: (opts: ToastOptions) => Promise<void>
 }

--- a/src/ui/editor/editorView.ts
+++ b/src/ui/editor/editorView.ts
@@ -87,7 +87,7 @@ function renderActionsBar(ctrl: EditorCtrl) {
     }),
     h('button.action_bar_button.fa.fa-share-alt', {
       oncreate: helper.ontap(
-        () => Plugins.LiShare.share({ text: ctrl.getLegalFen() }),
+        () => Plugins.LiShare.share({ text: ctrl.getLegalFen() ?? '' }),
         () => Plugins.LiToast.show({ text: 'Share FEN', duration: 'short', position: 'bottom' })
       )
     })

--- a/src/ui/shared/round/view/roundView.tsx
+++ b/src/ui/shared/round/view/roundView.tsx
@@ -290,10 +290,10 @@ function userInfos(user: User, player: Player, playerName: string) {
 
 function renderPlayerName(player: Player) {
   if (player.name || player.username || player.user) {
-    const name = player.name || player.username || player.user?.username
+    const name = player.name ?? player.username ?? player.user?.username
     return h('span', [
-      player.user?.title ? [
-        h('span.userTitle' + (player.user?.title === 'BOT' ? '.bot' : ''), player.user.title),
+      player.user?.title != null ? [
+        h('span.userTitle' + (player.user.title === 'BOT' ? '.bot' : ''), player.user.title),
         ' '
       ] : [],
       name
@@ -305,13 +305,28 @@ function renderPlayerName(player: Player) {
   return 'Anonymous'
 }
 
+function getPlayerName(player: Player): string {
+  if (player.name != null || player.username != null || player.user) {
+    const name = player.name ?? player.username ?? player.user?.username
+    if (player.user?.title != null) {
+      return `${player.user.title} ${name}`
+    } else {
+      return name ?? 'Unknown'
+    }
+  }
+
+  if (player.ai != null) return playerApi.aiName({ ai: player.ai })
+
+  return 'Anonymous'
+}
+
 function renderAntagonistInfo(ctrl: OnlineRound, player: Player, material: Material, position: Position, isCrazy: boolean) {
   const user = player.user
   const playerName = renderPlayerName(player)
   const togglePopup = user ? () => ctrl.openUserPopup(position, user.id) : utils.noop
   const vConf = user ?
     helper.ontap(togglePopup, () => userInfos(user, player, playerApi.playerName(player))) :
-    helper.ontap(utils.noop, () => Plugins.LiToast.show({ text: playerName, duration: 'short' }))
+    helper.ontap(utils.noop, () => Plugins.LiToast.show({ text: getPlayerName(player), duration: 'short' }))
 
   const checksNb = getChecksCount(ctrl, player.color)
 


### PR DESCRIPTION
This will be moot in Capacitor 3, as plugins will be [imported directly](https://capacitorjs.com/docs/updating/3-0#plugin-imports) and not through the Capacitor PluginRegistry. Nice to have for now though.

### Before
```
✖ 2446 problems (0 errors, 2446 warnings)
```

### After
```
✖ 2445 problems (0 errors, 2445 warnings)
```

(all of the "any type" problems became "[no floating promises](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-floating-promises.md)" errors 😢 )