### PR TITLE
Move global pawn promotion state to round control objects

### DIFF
--- a/src/ui/ai/AiRound.ts
+++ b/src/ui/ai/AiRound.ts
@@ -15,7 +15,7 @@ import { StoredOfflineGame, setCurrentAIGame } from '../../utils/offlineGames'
 import { OfflineGameData, GameStatus } from '../../lichess/interfaces/game'
 import redraw from '../../utils/redraw'
 
-import promotion from '../shared/offlineRound/promotion'
+import promotion, { Promoting } from '../shared/offlineRound/promotion'
 import ground from '../shared/offlineRound/ground'
 import makeData from '../shared/offlineRound/data'
 import { setResult } from '../shared/offlineRound'
@@ -42,6 +42,7 @@ export default class AiRound implements AiRoundInterface, PromotingInterface {
   public newGameMenu: NewAiGameCtrl
   public vm: AiVM
   public moveList: boolean
+  public promoting: Promoting | null = null
 
   public engine?: Engine
 

--- a/src/ui/ai/AiRound.ts
+++ b/src/ui/ai/AiRound.ts
@@ -266,7 +266,7 @@ export default class AiRound implements AiRoundInterface, PromotingInterface {
   }
 
   private userMove = (orig: Key, dest: Key) => {
-    if (!promotion.start(this.chessground, orig, dest, this.onPromotion)) {
+    if (!promotion.start(this, orig, dest, this.onPromotion)) {
       this.replay.addMove(orig, dest)
     }
   }

--- a/src/ui/ai/aiView.tsx
+++ b/src/ui/ai/aiView.tsx
@@ -11,6 +11,7 @@ import * as helper from '../helper'
 import actions from './actions'
 import newGameMenu from './newAiGame'
 import AiRound from './AiRound'
+import { noop } from '~/chessground/util'
 
 export function renderContent(ctrl: AiRound) {
 
@@ -58,7 +59,7 @@ export function overlay(ctrl: AiRound) {
   return [
     actions.view(ctrl.actions),
     newGameMenu.view(ctrl.newGameMenu),
-    renderPromotion(ctrl)
+    renderPromotion(ctrl, noop) // Cannot
   ]
 }
 

--- a/src/ui/ai/aiView.tsx
+++ b/src/ui/ai/aiView.tsx
@@ -11,7 +11,6 @@ import * as helper from '../helper'
 import actions from './actions'
 import newGameMenu from './newAiGame'
 import AiRound from './AiRound'
-import { noop } from '~/chessground/util'
 
 export function renderContent(ctrl: AiRound) {
 
@@ -59,7 +58,7 @@ export function overlay(ctrl: AiRound) {
   return [
     actions.view(ctrl.actions),
     newGameMenu.view(ctrl.newGameMenu),
-    renderPromotion(ctrl, noop) // Cannot
+    renderPromotion(ctrl)
   ]
 }
 

--- a/src/ui/analyse/AnalyseCtrl.ts
+++ b/src/ui/analyse/AnalyseCtrl.ts
@@ -382,7 +382,6 @@ export default class AnalyseCtrl implements PromotingInterface {
     this.ceval.stop()
     this.debouncedExplorerSetStep()
     this.updateHref()
-    promotion.cancel(this, this.cgConfig)
     if (pathChanged) {
       if (this.retro) this.retro.onJump()
       if (this.practice) this.practice.onJump()

--- a/src/ui/analyse/AnalyseCtrl.ts
+++ b/src/ui/analyse/AnalyseCtrl.ts
@@ -21,7 +21,7 @@ import * as gameApi from '../../lichess/game'
 import { AnalyseData, AnalyseDataWithTree, isOnlineAnalyseData } from '../../lichess/interfaces/analyse'
 import { Study, findTag } from '../../lichess/interfaces/study'
 import { Opening } from '../../lichess/interfaces/game'
-import promotion from '../shared/offlineRound/promotion'
+import promotion, { Promoting } from '../shared/offlineRound/promotion'
 import continuePopup, { Controller as ContinuePopupController } from '../shared/continuePopup'
 import { NotesCtrl } from '../shared/round/notes'
 
@@ -59,6 +59,7 @@ export default class AnalyseCtrl {
   evalCache: EvalCache
   study?: StudyCtrl
   forecast?: ForecastCtrl
+  promoting: Promoting | null = null
 
   socket: SocketIFace
 
@@ -380,7 +381,7 @@ export default class AnalyseCtrl {
     this.ceval.stop()
     this.debouncedExplorerSetStep()
     this.updateHref()
-    promotion.cancel(this.chessground, this.cgConfig)
+    promotion.cancel(this, this.cgConfig)
     if (pathChanged) {
       if (this.retro) this.retro.onJump()
       if (this.practice) this.practice.onJump()
@@ -594,7 +595,7 @@ export default class AnalyseCtrl {
   private userMove = (orig: Key, dest: Key, captured?: Piece) => {
     if (captured) sound.capture()
     else sound.move()
-    if (!promotion.start(this.chessground, orig, dest, this.sendMove)) this.sendMove(orig, dest)
+    if (!promotion.start(this, orig, dest, this.sendMove)) this.sendMove(orig, dest)
   }
 
   private userNewPiece = (piece: Piece, pos: Key) => {

--- a/src/ui/analyse/AnalyseCtrl.ts
+++ b/src/ui/analyse/AnalyseCtrl.ts
@@ -42,8 +42,9 @@ import { Source } from './interfaces'
 import * as tabs from './tabs'
 import StudyCtrl from './study/StudyCtrl'
 import ForecastCtrl from './forecast/ForecastCtrl'
+import { PromotingInterface } from '../shared/round'
 
-export default class AnalyseCtrl {
+export default class AnalyseCtrl implements PromotingInterface {
 
   settings: ISettingsCtrl
   menu: IMainMenuCtrl

--- a/src/ui/otb/OtbRound.ts
+++ b/src/ui/otb/OtbRound.ts
@@ -213,7 +213,7 @@ export default class OtbRound implements OtbRoundInterface, PromotingInterface {
   }
 
   private userMove = (orig: Key, dest: Key) => {
-    if (!promotion.start(this.chessground, orig, dest, this.onPromotion)) {
+    if (!promotion.start(this, orig, dest, this.onPromotion)) {
       this.replay.addMove(orig, dest)
     }
   }

--- a/src/ui/otb/OtbRound.ts
+++ b/src/ui/otb/OtbRound.ts
@@ -11,7 +11,7 @@ import { oppositeColor } from '../../utils'
 import { StoredOfflineGame, setCurrentOTBGame } from '../../utils/offlineGames'
 import redraw from '../../utils/redraw'
 
-import promotion from '../shared/offlineRound/promotion'
+import promotion, { Promoting } from '../shared/offlineRound/promotion'
 import ground from '../shared/offlineRound/ground'
 import makeData from '../shared/offlineRound/data'
 import { setResult } from '../shared/offlineRound'
@@ -43,6 +43,7 @@ export default class OtbRound implements OtbRoundInterface, PromotingInterface {
   public vm: OtbVM
   public clock?: IChessClock
   public moveList: boolean
+  public promoting: Promoting | null = null
 
   private appStateListener: PluginListenerHandle
 

--- a/src/ui/shared/offlineRound/promotion.ts
+++ b/src/ui/shared/offlineRound/promotion.ts
@@ -7,20 +7,18 @@ import h from 'mithril/hyperscript'
 import { PromotingInterface } from '../round'
 
 type PromoteCallback = (orig: Key, dest: Key, prom: Role) => void
-interface Promoting {
+export interface Promoting {
   orig: Key
   dest: Key
   callback: PromoteCallback
 }
 
-let promoting: Promoting | null = null
-
-function start(chessground: Chessground, orig: Key, dest: Key, callback: PromoteCallback) {
-  const piece = chessground.state.pieces.get(dest)
+function start(ctrl: PromotingInterface, orig: Key, dest: Key, callback: PromoteCallback) {
+  const piece = ctrl.chessground.state.pieces.get(dest)
   if (piece && piece.role === 'pawn' && (
-    (dest[1] === '1' && chessground.state.turnColor === 'white') ||
-    (dest[1] === '8' && chessground.state.turnColor === 'black'))) {
-    promoting = {
+    (dest[1] === '1' && ctrl.chessground.state.turnColor === 'white') ||
+    (dest[1] === '8' && ctrl.chessground.state.turnColor === 'black'))) {
+    ctrl.promoting = {
       orig: orig,
       dest: dest,
       callback: callback
@@ -31,22 +29,23 @@ function start(chessground: Chessground, orig: Key, dest: Key, callback: Promote
   return false
 }
 
-function finish(chessground: Chessground, role: Role) {
-  if (promoting) chessground.promote(promoting.dest, role)
-  if (promoting && promoting.callback) promoting.callback(promoting.orig, promoting.dest, role)
-  promoting = null
+function finish(ctrl: PromotingInterface, role: Role) {
+  const promoting = ctrl.promoting
+  if (promoting) ctrl.chessground.promote(promoting.dest, role)
+  promoting?.callback(promoting.orig, promoting.dest, role)
+  ctrl.promoting = null
 }
 
-function cancel(chessground: Chessground, cgConfig?: cg.SetConfig) {
-  if (promoting) {
-    promoting = null
-    if (cgConfig) chessground.set(cgConfig)
+function cancel(ctrl: PromotingInterface, cgConfig?: cg.SetConfig) {
+  if (ctrl.promoting) {
+    ctrl.promoting = null
+    if (cgConfig) ctrl.chessground.set(cgConfig)
     redraw()
   }
 }
 
 export function view(ctrl: PromotingInterface) {
-  if (!promoting) return null
+  if (!ctrl.promoting) return null
 
   const pieces: Role[] = ['queen', 'knight', 'rook', 'bishop']
   if (ctrl.data && ctrl.data.game.variant.key === 'antichess') {
@@ -58,7 +57,7 @@ export function view(ctrl: PromotingInterface) {
     style: { top: (helper.viewportDim().vh - 100) / 2 + 'px' }
   }, pieces.map((role: Role) => {
     return h('piece.' + role + '.' + ctrl.player(), {
-      oncreate: helper.ontap(() => finish(ctrl.chessground, role))
+      oncreate: helper.ontap(() => finish(ctrl, role))
     })
   }))])
 }

--- a/src/ui/shared/offlineRound/promotion.ts
+++ b/src/ui/shared/offlineRound/promotion.ts
@@ -30,8 +30,10 @@ function start(ctrl: PromotingInterface, orig: Key, dest: Key, callback: Promote
 
 function finish(ctrl: PromotingInterface, role: Role) {
   const promoting = ctrl.promoting
-  if (promoting) ctrl.chessground.promote(promoting.dest, role)
-  promoting?.callback(promoting.orig, promoting.dest, role)
+  if (promoting) {
+    ctrl.chessground.promote(promoting.dest, role)
+    promoting.callback(promoting.orig, promoting.dest, role)
+  }
   ctrl.promoting = null
 }
 
@@ -43,7 +45,7 @@ function cancel(ctrl: PromotingInterface, cgConfig?: cg.SetConfig) {
   }
 }
 
-export function view(ctrl: PromotingInterface) {
+export function view(ctrl: PromotingInterface, cancel: (i: PromotingInterface) => void) {
   if (!ctrl.promoting) return null
 
   const pieces: Role[] = ['queen', 'knight', 'rook', 'bishop']
@@ -51,7 +53,9 @@ export function view(ctrl: PromotingInterface) {
     pieces.push('king')
   }
 
-  return h('div.overlay.open', [h('div#promotion_choice', {
+  return h('div.overlay.open', {
+    oncreate: helper.ontap(() => cancel(ctrl))
+  }, [h('div#promotion_choice', {
     className: settings.general.theme.piece(),
     style: { top: (helper.viewportDim().vh - 100) / 2 + 'px' }
   }, pieces.map((role: Role) => {
@@ -63,5 +67,7 @@ export function view(ctrl: PromotingInterface) {
 
 export default {
   start,
-  cancel
+  cancel,
+  finish,
+  view
 }

--- a/src/ui/shared/offlineRound/promotion.ts
+++ b/src/ui/shared/offlineRound/promotion.ts
@@ -4,6 +4,7 @@ import * as helper from '../../helper'
 import settings from '../../../settings'
 import h from 'mithril/hyperscript'
 import { PromotingInterface } from '../round'
+import { noop } from '~/utils'
 
 type PromoteCallback = (orig: Key, dest: Key, prom: Role) => void
 export interface Promoting {
@@ -45,7 +46,7 @@ function cancel(ctrl: PromotingInterface, cgConfig?: cg.SetConfig) {
   }
 }
 
-export function view<T extends PromotingInterface>(ctrl: T, cancelCallback: (ctrl: T) => void = cancel) {
+export function view<T extends PromotingInterface>(ctrl: T, cancelCallback: (ctrl: T) => void = noop) {
   if (!ctrl.promoting) return null
 
   const pieces: Role[] = ['queen', 'knight', 'rook', 'bishop']

--- a/src/ui/shared/offlineRound/promotion.ts
+++ b/src/ui/shared/offlineRound/promotion.ts
@@ -45,7 +45,7 @@ function cancel(ctrl: PromotingInterface, cgConfig?: cg.SetConfig) {
   }
 }
 
-export function view(ctrl: PromotingInterface, cancel: (i: PromotingInterface) => void) {
+export function view<T extends PromotingInterface>(ctrl: T, cancelCallback: (ctrl: T) => void = cancel) {
   if (!ctrl.promoting) return null
 
   const pieces: Role[] = ['queen', 'knight', 'rook', 'bishop']
@@ -54,7 +54,7 @@ export function view(ctrl: PromotingInterface, cancel: (i: PromotingInterface) =
   }
 
   return h('div.overlay.open', {
-    oncreate: helper.ontap(() => cancel(ctrl))
+    oncreate: helper.ontap(() => cancelCallback(ctrl))
   }, [h('div#promotion_choice', {
     className: settings.general.theme.piece(),
     style: { top: (helper.viewportDim().vh - 100) / 2 + 'px' }

--- a/src/ui/shared/offlineRound/promotion.ts
+++ b/src/ui/shared/offlineRound/promotion.ts
@@ -1,5 +1,4 @@
 import redraw from '../../../utils/redraw'
-import Chessground from '../../../chessground/Chessground'
 import * as cg from '../../../chessground/interfaces'
 import * as helper from '../../helper'
 import settings from '../../../settings'

--- a/src/ui/shared/offlineRound/promotion.ts
+++ b/src/ui/shared/offlineRound/promotion.ts
@@ -50,7 +50,7 @@ export function view<T extends PromotingInterface>(ctrl: T, cancelCallback: (ctr
   if (!ctrl.promoting) return null
 
   const pieces: Role[] = ['queen', 'knight', 'rook', 'bishop']
-  if (ctrl.data && ctrl.data.game.variant.key === 'antichess') {
+  if (ctrl.data.game.variant.key === 'antichess') {
     pieces.push('king')
   }
 
@@ -58,7 +58,7 @@ export function view<T extends PromotingInterface>(ctrl: T, cancelCallback: (ctr
     oncreate: helper.ontap(() => cancelCallback(ctrl))
   }, [h('div#promotion_choice', {
     className: settings.general.theme.piece(),
-    style: { top: (helper.viewportDim().vh - 100) / 2 + 'px' }
+    style: { top: `${(helper.viewportDim().vh - 100) / 2}px` }
   }, pieces.map((role: Role) => {
     return h('piece.' + role + '.' + ctrl.player(), {
       oncreate: helper.ontap(() => finish(ctrl, role))
@@ -69,6 +69,5 @@ export function view<T extends PromotingInterface>(ctrl: T, cancelCallback: (ctr
 export default {
   start,
   cancel,
-  finish,
   view
 }

--- a/src/ui/shared/round/OnlineRound.ts
+++ b/src/ui/shared/round/OnlineRound.ts
@@ -32,6 +32,7 @@ import atomic from './atomic'
 import * as xhr from './roundXhr'
 import crazyValid from './crazy/crazyValid'
 import { OnlineRoundInterface } from './'
+import { Promoting } from '../offlineRound/promotion'
 
 interface VM {
   ply: number
@@ -67,6 +68,7 @@ export default class OnlineRound implements OnlineRoundInterface {
   public tv!: string
   public score?: Score
   public socket: RoundSocket
+  public promoting: Promoting | null = null
 
   private zenModeEnabled: boolean
   private lastMoveMillis?: number
@@ -167,6 +169,8 @@ export default class OnlineRound implements OnlineRoundInterface {
 
     redraw()
   }
+
+  public player = () => this.data.player.color
 
   public zenAvailable = () => !this.data.player.spectator &&
     gameApi.playable(this.data)

--- a/src/ui/shared/round/index.ts
+++ b/src/ui/shared/round/index.ts
@@ -5,6 +5,7 @@ import { AnalyseData } from '../../../lichess/interfaces/analyse'
 import { GameSituation } from '../../../chess'
 import { Data as TrainingData } from '../../training/interfaces'
 import { ClockType } from '../clock/interfaces'
+import { Promoting } from '../offlineRound/promotion'
 
 export type Position = 'player' | 'opponent'
 export type Material = { pieces: { [k: string]: number }, score: number }
@@ -15,6 +16,7 @@ export interface BoardInterface {
 }
 
 export interface PromotingInterface {
+  promoting: Promoting | null
   chessground: Chessground
   data: GameData | AnalyseData | TrainingData
   player: () => Color

--- a/src/ui/shared/round/index.ts
+++ b/src/ui/shared/round/index.ts
@@ -34,7 +34,7 @@ export interface RoundInterface extends BoardInterface {
   jumpLast(): boolean
 }
 
-export interface OnlineRoundInterface extends RoundInterface {
+export interface OnlineRoundInterface extends RoundInterface, PromotingInterface {
   data: OnlineGameData
 
   onReload(cfg: OnlineGameData): void

--- a/src/ui/shared/round/promotion.ts
+++ b/src/ui/shared/round/promotion.ts
@@ -1,17 +1,16 @@
 import redraw from '../../../utils/redraw'
 import { OnlineRoundInterface } from '.'
-import { noop } from '~/chessground/util'
 import promotion from '../offlineRound/promotion'
 
 function start(ctrl: OnlineRoundInterface, orig: Key, dest: Key, isPremove: boolean) {
   const piece = ctrl.chessground.state.pieces.get(dest)
   if (piece && piece.role === 'pawn' && (
-    (dest[1] === '8' && ctrl.chessground.state.turnColor === 'white') ||
-    (dest[1] === '1' && ctrl.chessground.state.turnColor === 'black'))) {
+    (dest[1] === '8' && ctrl.player() === 'white') ||
+    (dest[1] === '1' && ctrl.player() === 'black'))) {
     if (ctrl.data.pref.autoQueen === 3 || (ctrl.data.pref.autoQueen === 2 && isPremove)) return false
     ctrl.promoting = {
       orig, dest,
-      callback: noop
+      callback: (orig, dest, role) => ctrl.sendMove(orig, dest, role)
     }
     redraw()
     return true
@@ -20,7 +19,6 @@ function start(ctrl: OnlineRoundInterface, orig: Key, dest: Key, isPremove: bool
 }
 
 function cancel(ctrl: OnlineRoundInterface) {
-  console.log('online cancel', ctrl.promoting)
   if (ctrl.promoting) ctrl.reloadGameData()
   ctrl.promoting = null
 }

--- a/src/ui/shared/round/promotion.ts
+++ b/src/ui/shared/round/promotion.ts
@@ -1,9 +1,7 @@
-import h from 'mithril/hyperscript'
 import redraw from '../../../utils/redraw'
-import settings from '../../../settings'
-import * as helper from '../../helper'
 import { OnlineRoundInterface } from '.'
 import { noop } from '~/chessground/util'
+import promotion from '../offlineRound/promotion'
 
 function start(ctrl: OnlineRoundInterface, orig: Key, dest: Key, isPremove: boolean) {
   const piece = ctrl.chessground.state.pieces.get(dest)
@@ -21,15 +19,6 @@ function start(ctrl: OnlineRoundInterface, orig: Key, dest: Key, isPremove: bool
   return false
 }
 
-function finish(ctrl: OnlineRoundInterface, role: Role) {
-  const promoting = ctrl.promoting
-  if (promoting) {
-    ctrl.chessground.promote(promoting.dest, role)
-    ctrl.sendMove(promoting.orig, promoting.dest, role)
-  }
-  ctrl.promoting = null
-}
-
 function cancel(ctrl: OnlineRoundInterface) {
   if (ctrl.promoting) ctrl.reloadGameData()
   ctrl.promoting = null
@@ -39,22 +28,5 @@ export default {
 
   start: start,
 
-  view: function(ctrl: OnlineRoundInterface) {
-    if (!ctrl.promoting) return null
-
-    const pieces: Role[] = ['queen', 'knight', 'rook', 'bishop']
-
-    if (ctrl.data.game.variant.key === 'antichess') pieces.push('king')
-
-    return h('div.overlay.open', {
-      oncreate: helper.ontap(() => cancel(ctrl))
-    }, [h('div#promotion_choice', {
-      className: settings.general.theme.piece(),
-      style: { top: (helper.viewportDim().vh - 100) / 2 + 'px' }
-    }, pieces.map((role) => {
-      return h('piece.' + role + '.' + ctrl.data.player.color, {
-        oncreate: helper.ontap(() => finish(ctrl, role))
-      })
-    }))])
-  }
+  view: (ctrl: OnlineRoundInterface) => promotion.view(ctrl, () => cancel(ctrl))
 }

--- a/src/ui/shared/round/promotion.ts
+++ b/src/ui/shared/round/promotion.ts
@@ -20,6 +20,7 @@ function start(ctrl: OnlineRoundInterface, orig: Key, dest: Key, isPremove: bool
 }
 
 function cancel(ctrl: OnlineRoundInterface) {
+  console.log('online cancel', ctrl.promoting)
   if (ctrl.promoting) ctrl.reloadGameData()
   ctrl.promoting = null
 }
@@ -28,5 +29,5 @@ export default {
 
   start: start,
 
-  view: (ctrl: OnlineRoundInterface) => promotion.view(ctrl, () => cancel(ctrl))
+  view: (ctrl: OnlineRoundInterface) => promotion.view(ctrl, cancel)
 }

--- a/src/ui/training/TrainingCtrl.ts
+++ b/src/ui/training/TrainingCtrl.ts
@@ -13,7 +13,7 @@ import * as chessFormat from '../../utils/chessFormat'
 import session from '../../session'
 import sound from '../../sound'
 import { PuzzleData } from '../../lichess/interfaces/training'
-import promotion from '../shared/offlineRound/promotion'
+import promotion, { Promoting } from '../shared/offlineRound/promotion'
 import { PromotingInterface } from '../shared/round'
 
 import moveTest from './moveTest'
@@ -29,6 +29,7 @@ export default class TrainingCtrl implements PromotingInterface {
   menu: IMenuCtrl
   chessground!: Chessground
   database: Database
+  promoting: Promoting | null = null
 
   // current tree state, cursor, and denormalized node lists
   path!: Tree.Path
@@ -92,7 +93,7 @@ export default class TrainingCtrl implements PromotingInterface {
       if (this.node.san && this.node.san.indexOf('x') !== -1) sound.throttledCapture()
       else sound.throttledMove()
     }
-    promotion.cancel(this.chessground)
+    promotion.cancel(this)
   }
 
   public userJump = (path: Tree.Path, withSound: boolean): void => {
@@ -381,7 +382,7 @@ export default class TrainingCtrl implements PromotingInterface {
   private userMove = (orig: Key, dest: Key, captured?: Piece) => {
     if (captured) sound.capture()
     else sound.move()
-    if (!promotion.start(this.chessground, orig, dest, this.sendMove)) {
+    if (!promotion.start(this, orig, dest, this.sendMove)) {
       this.sendMove(orig, dest)
     }
   }


### PR DESCRIPTION
Closes #1168.

## Before

https://user-images.githubusercontent.com/569991/126903790-ed249a2f-4db4-4613-a027-a8b239fbd1d1.mov


https://user-images.githubusercontent.com/569991/126903792-66f540f7-7d13-470b-89f0-a82c127b4a71.mov


https://user-images.githubusercontent.com/569991/126903793-a979fe16-47f9-496d-be10-c80862875f4c.mov

## After

https://user-images.githubusercontent.com/569991/126903806-84f56062-6047-49b0-a67e-ecdd70412e45.mov


https://user-images.githubusercontent.com/569991/126903807-452c71c5-f3a3-4947-bcd5-38414ef20b51.mov


https://user-images.githubusercontent.com/569991/126903809-a0a438e6-d930-41f8-94fd-471b28a51d27.mov


