### PR TITLE
Fix broken challenge icons

### DIFF
--- a/src/lichess/interfaces/challenge.ts
+++ b/src/lichess/interfaces/challenge.ts
@@ -37,6 +37,7 @@ export interface Challenge {
   readonly variant: Variant
   readonly initialFen: string | null
   readonly rated: boolean
+  readonly speed: Speed
   readonly timeControl: TimeControl
   readonly color: Color | 'random'
   readonly perf: {

--- a/src/ui/gamesMenu.ts
+++ b/src/ui/gamesMenu.ts
@@ -197,7 +197,7 @@ function renderIncomingChallenge(c: Challenge) {
   }, [
     renderViewOnlyBoard(c.initialFen || standardFen, 'white', undefined, c.variant.key),
     h('div.infos', [
-      h('div.icon-game', { 'data-icon': c.perf.icon }),
+      h('div.icon-game', { 'data-icon': utils.gameIcon(c.speed) }),
       h('div.description', [
         h('h2.title', i18n('playerisInvitingYou', playerName)),
         h('p.variant', [
@@ -240,7 +240,7 @@ function renderSendingChallenge(c: Challenge) {
   }, [
     renderViewOnlyBoard(c.initialFen || standardFen, 'white', undefined, c.variant.key),
     h('div.infos', [
-      h('div.icon-game', { 'data-icon': c.perf.icon }),
+      h('div.icon-game', { 'data-icon': utils.gameIcon(c.speed) }),
       h('div.description', [
         h('h2.title', c.destUser ? playerName(c.destUser) : 'Open challenge'),
         h('p.variant', [


### PR DESCRIPTION
Closes #1800.

Challenge objects from the API [include a `speed` key](https://github.com/ornicar/lila/blob/44fd283b88f289ce5ad928229e07b3c578903949/modules/challenge/src/main/JsonView.scala#L62). Similarly to https://github.com/veloce/lichobile/issues/1724#issuecomment-861435887 , which was basically this same issue but for tournament icons, we should use that instead of the server-specified icon to choose what icon to show.

Tested locally.