### PR TITLE
Fix promotion

### DIFF
--- a/src/stockfish.ts
+++ b/src/stockfish.ts
@@ -65,8 +65,6 @@ export class StockfishPlugin {
     if (this.isVariant()) {
       if (this.variant === 'threeCheck')
         return this.setOption('UCI_Variant', '3check')
-      else if (this.variant === 'antichess')
-        return this.setOption('UCI_Variant', 'giveaway')
       else
         return this.setOption('UCI_Variant', this.variant.toLowerCase())
     } else {

--- a/src/stockfish.ts
+++ b/src/stockfish.ts
@@ -65,6 +65,8 @@ export class StockfishPlugin {
     if (this.isVariant()) {
       if (this.variant === 'threeCheck')
         return this.setOption('UCI_Variant', '3check')
+      else if (this.variant === 'antichess')
+        return this.setOption('UCI_Variant', 'giveaway')
       else
         return this.setOption('UCI_Variant', this.variant.toLowerCase())
     } else {

--- a/src/ui/ai/AiRound.ts
+++ b/src/ui/ai/AiRound.ts
@@ -28,7 +28,6 @@ import Replay from '../shared/offlineRound/Replay'
 import actions, { AiActionsCtrl } from './actions'
 import Engine from './engine'
 import newGameMenu, { NewAiGameCtrl } from './newAiGame'
-import { charToRole } from 'chessops/util'
 
 interface InitPayload {
   variant: VariantKey
@@ -226,16 +225,10 @@ export default class AiRound implements AiRoundInterface, PromotingInterface {
   public onEngineMove = (bestmove: string) => {
     const from = <Key>bestmove.slice(0, 2)
     const to = <Key>bestmove.slice(2, 4)
+    const role = <Role>chessFormat.uciToProm(bestmove)
     this.vm.engineSearching = false
-    // does the promotion piece have to be passed to this function as well?
     this.chessground.apiMove(from, to)
-    if (bestmove.length > 4) {
-      const role = charToRole(bestmove.slice(4,5))
-      this.replay.addMove(from, to, role)
-    } else {
-      // inelegant to have this switch. Is there an empty Role to pass instead?
-      this.replay.addMove(from, to)
-    }
+		this.replay.addMove(from, to, role)
     redraw()
   }
 

--- a/src/ui/ai/AiRound.ts
+++ b/src/ui/ai/AiRound.ts
@@ -28,6 +28,7 @@ import Replay from '../shared/offlineRound/Replay'
 import actions, { AiActionsCtrl } from './actions'
 import Engine from './engine'
 import newGameMenu, { NewAiGameCtrl } from './newAiGame'
+import { charToRole } from 'chessops/util'
 
 interface InitPayload {
   variant: VariantKey
@@ -225,10 +226,16 @@ export default class AiRound implements AiRoundInterface, PromotingInterface {
   public onEngineMove = (bestmove: string) => {
     const from = <Key>bestmove.slice(0, 2)
     const to = <Key>bestmove.slice(2, 4)
-    const role = <Role>bestmove.slice(4, 5)
     this.vm.engineSearching = false
+    // does the promotion piece have to be passed to this function as well?
     this.chessground.apiMove(from, to)
-    this.replay.addMove(from, to, role)
+    if (bestmove.length > 4) {
+      const role = charToRole(bestmove.slice(4,5))
+      this.replay.addMove(from, to, role)
+    } else {
+      // inelegant to have this switch. Is there an empty Role to pass instead?
+      this.replay.addMove(from, to)
+    }
     redraw()
   }
 

--- a/src/ui/ai/AiRound.ts
+++ b/src/ui/ai/AiRound.ts
@@ -225,9 +225,10 @@ export default class AiRound implements AiRoundInterface, PromotingInterface {
   public onEngineMove = (bestmove: string) => {
     const from = <Key>bestmove.slice(0, 2)
     const to = <Key>bestmove.slice(2, 4)
-    const role = <Role>chessFormat.uciToProm(bestmove)
+    const role = chessFormat.uciToProm(bestmove)
     this.vm.engineSearching = false
     this.chessground.apiMove(from, to)
+		// perhaps tell chessground that a promotion has happened if role is nonempty?
     this.replay.addMove(from, to, role)
     redraw()
   }

--- a/src/ui/ai/AiRound.ts
+++ b/src/ui/ai/AiRound.ts
@@ -228,7 +228,7 @@ export default class AiRound implements AiRoundInterface, PromotingInterface {
     const role = <Role>chessFormat.uciToProm(bestmove)
     this.vm.engineSearching = false
     this.chessground.apiMove(from, to)
-		this.replay.addMove(from, to, role)
+    this.replay.addMove(from, to, role)
     redraw()
   }
 

--- a/src/ui/ai/AiRound.ts
+++ b/src/ui/ai/AiRound.ts
@@ -225,9 +225,10 @@ export default class AiRound implements AiRoundInterface, PromotingInterface {
   public onEngineMove = (bestmove: string) => {
     const from = <Key>bestmove.slice(0, 2)
     const to = <Key>bestmove.slice(2, 4)
+    const role = <Role>bestmove.slice(4, 5)
     this.vm.engineSearching = false
     this.chessground.apiMove(from, to)
-    this.replay.addMove(from, to)
+    this.replay.addMove(from, to, role)
     redraw()
   }
 

--- a/src/ui/ai/engine.ts
+++ b/src/ui/ai/engine.ts
@@ -12,7 +12,7 @@ export default class Engine {
     this.listener = (e: Event) => {
       const line = (e as any).output
       console.debug('[stockfish >>] ' + line)
-      const bmMatch = line.match(/^bestmove (\w{4})|^bestmove ([PNBRQ]@\w{2})/)
+      const bmMatch = line.match(/^bestmove (\w{4,5})|^bestmove ([PNBRQ]@\w{2})/)
       if (bmMatch) {
         if (bmMatch[1]) this.ctrl.onEngineMove(bmMatch[1])
         else if (bmMatch[2]) this.ctrl.onEngineDrop(bmMatch[2])


### PR DESCRIPTION
Promotion piece received from engine now passed forward. This should close #1802.
In testing, it seems that the proper variant string had not been passed on. This is perhaps a separate issue, in commit 3050342.