### PR TITLE
Disable ceval for illegal FEN on analyse board

### DIFF
--- a/src/ui/analyse/AnalyseCtrl.ts
+++ b/src/ui/analyse/AnalyseCtrl.ts
@@ -42,6 +42,7 @@ import { Source } from './interfaces'
 import * as tabs from './tabs'
 import StudyCtrl from './study/StudyCtrl'
 import ForecastCtrl from './forecast/ForecastCtrl'
+import { positionLooksLegit } from '~/utils/fen'
 
 export default class AnalyseCtrl {
 
@@ -131,6 +132,12 @@ export default class AnalyseCtrl {
       }
 
       if (study && !(study.chapter.features.computer || study.chapter.practice)) {
+        return false
+      }
+
+      if (this.data.game.variant.key !== 'antichess' &&
+          this.data.game.variant.key !== 'horde' &&
+          !positionLooksLegit(this.data.game.fen)) {
         return false
       }
 


### PR DESCRIPTION
Closes #1725. All currently supported variants besides horde and antichess require exactly one king on each side.

## Before
(study: https://lichess.org/study/kI8ikTU4)
![Screen Shot 2021-09-01 at 9 55 54 AM](https://user-images.githubusercontent.com/569991/131684439-52faff70-5eac-4b70-8c9d-03af639e97a7.png)

## After
![Screen Shot 2021-09-01 at 9 56 16 AM](https://user-images.githubusercontent.com/569991/131684440-0208f3af-b904-4cff-b815-490f50bf494b.png)
