### PR TITLE
Variant mangling

### DIFF
--- a/src/stockfish.ts
+++ b/src/stockfish.ts
@@ -63,8 +63,10 @@ export class StockfishPlugin {
 
   public setVariant(): Promise<void> {
     if (this.isVariant()) {
-      if (this.variant === 'threeCheck')
+			if (Capacitor.platform !== 'web' && this.variant === 'threeCheck')
         return this.setOption('UCI_Variant', '3check')
+			if (Capacitor.platform === 'web' && this.variant === 'antichess')
+        return this.setOption('UCI_Variant', 'giveaway')
       else
         return this.setOption('UCI_Variant', this.variant.toLowerCase())
     } else {

--- a/src/stockfish.ts
+++ b/src/stockfish.ts
@@ -63,9 +63,9 @@ export class StockfishPlugin {
 
   public setVariant(): Promise<void> {
     if (this.isVariant()) {
-			if (Capacitor.platform !== 'web' && this.variant === 'threeCheck')
+      if (Capacitor.platform !== 'web' && this.variant === 'threeCheck')
         return this.setOption('UCI_Variant', '3check')
-			if (Capacitor.platform === 'web' && this.variant === 'antichess')
+      if (Capacitor.platform === 'web' && this.variant === 'antichess')
         return this.setOption('UCI_Variant', 'giveaway')
       else
         return this.setOption('UCI_Variant', this.variant.toLowerCase())


### PR DESCRIPTION
It seems that the web stockfish understands different variant strings than the mobile stockfish-capacitor? In my testing within the browser, it was necessary to pass different UCI_variant strings.