### PR TITLE
Disable best-effort dark mode

### DIFF
--- a/src/index.mustache
+++ b/src/index.mustache
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark" />
     <meta name="format-detection" content="telephone=no" />
     <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, width=device-width, viewport-fit=cover" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self' gap: data: https://ssl.gstatic.com; connect-src 'self' https://veloce.github.io https://explorer.lichess.ovh https://tablebase.lichess.ovh {{{apiEndPoint}}} {{{socketEndPoint}}}; script-src 'self' 'unsafe-inline'; child-src 'self' filesystem: gap://ready; style-src 'self' 'unsafe-inline'; img-src 'self' data: {{{apiEndPoint}}}; media-src 'self'">


### PR DESCRIPTION
Attempt to fix #1859.

> Best guess: the Xiaomi / MIUI default webview has a "best effort" dark mode that attempts to invert colors. Opening a "best effort" PR for this now

I don't have a Xiaomi device so I can't confirm this fixes the issue, but it shouldn't break anything (this app is already designed for dark mode w/internal theming). If anyone seeing this PR does have a Redmi 9 and can compile + install + test this branch, I'd be very grateful.