### PR TITLE
add Blindfold Chess mode

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -135,6 +135,7 @@ export default {
     magnified: prop<boolean>('pieceMagnified', true),
     pieceNotation: prop<boolean>('pieceNotation', true),
     zenMode: prop<boolean>('zenMode', false),
+    blindfoldChess: prop<boolean>('blindfoldChess', false),
     clockPosition: prop<'right' | 'left'>('game.inversedClockPos', 'right'),
     pieceMove: prop<'tap' | 'drag' | 'both'>('game.pieceMove', 'both'),
     rookCastle: prop<0 | 1>('game.rookCastle', 1),

--- a/src/styl/board-content.styl
+++ b/src/styl/board-content.styl
@@ -5,6 +5,12 @@
   flex-flow column nowrap
   justify-content center
   min-height 0 // fix chrome bug
+  .blindfold-true .manipulable piece
+      display none
+  .analyse-boardWrapper .blindfold-true .manipulable piece
+      display initial
+  .editor-board .blindfold-true .manipulable piece
+      display initial
   @media only screen and (orientation: portrait) and (min-width 768px) and (min-height 768px)
     .actions_bar
       width 94vw

--- a/src/ui/editor/editorView.ts
+++ b/src/ui/editor/editorView.ts
@@ -19,6 +19,7 @@ export default function view(ctrl: EditorCtrl) {
   const board = h(Board, {
     variant: 'standard',
     chessground: ctrl.chessground,
+    wrapperClasses: 'editor-board',
   })
 
   return layout.board(

--- a/src/ui/settings/gameDisplay.ts
+++ b/src/ui/settings/gameDisplay.ts
@@ -59,6 +59,9 @@ function renderBody() {
       ),
       h('li.list_item', [
         formWidgets.renderMultipleChoiceButton(i18n('zenMode'), formWidgets.booleanChoice, settings.game.zenMode),
+      ]),
+      h('li.list_item', [
+        formWidgets.renderMultipleChoiceButton(i18n('blindfoldChess'), formWidgets.booleanChoice, settings.game.blindfoldChess),
       ])
    ])
   ]

--- a/src/ui/shared/Board.tsx
+++ b/src/ui/shared/Board.tsx
@@ -20,6 +20,7 @@ interface State {
   boardOnRemove(): void
   boardTheme: string
   pieceTheme: string
+  blindfoldChess: boolean
   shapesCleared: boolean
   bounds?: ClientRect
   onResize: () => void
@@ -57,6 +58,7 @@ export default {
     this.shapesCleared = false
     this.pieceTheme = settings.general.theme.piece()
     this.boardTheme = settings.general.theme.board()
+    this.blindfoldChess = settings.game.blindfoldChess()
   },
 
   onbeforeupdate({ attrs }, { attrs: oldattrs }) {
@@ -76,6 +78,7 @@ export default {
       'orientation-' + chessground.state.orientation,
       `board-${this.boardTheme}`,
       customPieceTheme || this.pieceTheme,
+      `blindfold-${this.blindfoldChess}`,
       variant
     ].join(' ')
 


### PR DESCRIPTION
A simple implementation of the blindfold chess mode available on the website.

It use css `display: none` on piece tags in order to hide pieces.

When enable pieces are hidden only during the game, which means that analysis, editor, TV or any watched game are not impacted.

Let me know your thoughts.