### PR TITLE
Tournament bug fixes and improvements

### DIFF
--- a/src/lichess/tournament.ts
+++ b/src/lichess/tournament.ts
@@ -3,3 +3,7 @@ import { Tournament } from './interfaces/tournament'
 export function isIn(data: Tournament): boolean {
   return !!(data.me && !data.me.withdraw)
 }
+
+export function previouslyJoined(data: Tournament): boolean {
+  return data.me != null
+}

--- a/src/ui/tournament/detail/TournamentCtrl.ts
+++ b/src/ui/tournament/detail/TournamentCtrl.ts
@@ -16,6 +16,8 @@ import faq, { FaqCtrl } from '../faq'
 import playerInfo, { PlayerInfoCtrl } from './playerInfo'
 import teamInfo, { TeamInfoCtrl } from './teamInfo'
 import socketHandler from './socketHandler'
+import { ErrorResponse } from '~/http'
+import { Toast } from '@capacitor/toast'
 
 const MAX_PER_PAGE = 10
 
@@ -95,7 +97,13 @@ export default class TournamentCtrl {
       this.focusOnMe = true
       redraw()
     })
-    .catch(utils.handleXhrError)
+    .catch((e: ErrorResponse) => {
+      if (e.body != null && 'error' in e.body) {
+        void Toast.show({ text: (e.body as {error: string}).error, duration: 'short' })
+      } else {
+        utils.handleXhrError(e)
+      }
+    })
   }, 1000)
 
   withdraw = throttle(() => {

--- a/src/ui/tournament/detail/tournamentView.tsx
+++ b/src/ui/tournament/detail/tournamentView.tsx
@@ -18,6 +18,7 @@ import playerInfo from './playerInfo'
 import teamInfo from './teamInfo'
 import joinForm from './joinForm'
 import TournamentCtrl from './TournamentCtrl'
+import { previouslyJoined } from '~/lichess/tournament'
 
 export function renderOverlay(ctrl: TournamentCtrl): Mithril.ChildArray {
   return [
@@ -188,7 +189,7 @@ function joinButton(ctrl: TournamentCtrl, t: Tournament) {
     (t.teamBattle && t.teamBattle.joinWith.length === 0)) {
     return h.fragment({key: 'noJoinButton'}, [])
   }
-  const action = (t.private || t.teamBattle) ?
+  const action = ((t.private || t.teamBattle) && !previouslyJoined(t)) ?
     () => joinForm.open(ctrl) :
     () => ctrl.join()
 

--- a/src/ui/tournament/detail/tournamentView.tsx
+++ b/src/ui/tournament/detail/tournamentView.tsx
@@ -19,7 +19,7 @@ import teamInfo from './teamInfo'
 import joinForm from './joinForm'
 import TournamentCtrl from './TournamentCtrl'
 
-export function renderOverlay(ctrl: TournamentCtrl) {
+export function renderOverlay(ctrl: TournamentCtrl): Mithril.ChildArray {
   return [
     faq.view(ctrl.faqCtrl),
     playerInfo.view(ctrl.playerInfoCtrl),
@@ -43,7 +43,7 @@ export function tournamentBody(ctrl: TournamentCtrl) {
   ])
 }
 
-export function renderFooter(ctrl: TournamentCtrl) {
+export function renderFooter(ctrl: TournamentCtrl): Mithril.Child {
   const t = ctrl.tournament
   if (!t) return null
   const tUrl = 'https://lichess.org/tournament/' + t.id
@@ -72,7 +72,7 @@ export function renderFooter(ctrl: TournamentCtrl) {
             { ctrl.chat.nbUnread <= 99 ? ctrl.chat.nbUnread : 99 }
           </span> : null
           }
-        </button> : null
+        </button> : h.fragment({key: 'noChat'}, [])
       }
       { ctrl.hasJoined ? withdrawButton(ctrl, t) : joinButton(ctrl, t) }
     </div>


### PR DESCRIPTION
Discovered while investigating #1897.

- Tournament with no chat enabled was crashing locally due to an unkeyed `null` node; replaced with empty keyed fragment
- Tournaments do not require re-entering passwords to resume play from pause, updated locally to not re-require password
- Tournament join API response contains an error message, display that to the user when available