### PR TITLE
Add check configuration to mini boards

### DIFF
--- a/src/ui/shared/ViewOnlyBoard.ts
+++ b/src/ui/shared/ViewOnlyBoard.ts
@@ -12,6 +12,7 @@ export interface Attrs {
   readonly variant?: VariantKey
   readonly fixed?: boolean
   readonly delay?: Millis
+  readonly check?: Color
 }
 
 interface Config {

--- a/src/ui/shared/miniBoard.tsx
+++ b/src/ui/shared/miniBoard.tsx
@@ -4,6 +4,8 @@ import { noop, formatTimeInSecs } from '../../utils'
 import { FeaturedGame2 } from '../../lichess/interfaces'
 import ViewOnlyBoard from './ViewOnlyBoard'
 import CountdownTimer from './CountdownTimer'
+import { parseFen } from 'chessops/fen'
+import { Chess } from 'chessops'
 
 export interface Attrs {
   readonly fen: string
@@ -33,6 +35,9 @@ const MiniBoard: Mithril.Component<Attrs, State> = {
 
     const { gameObj, topText, bottomText } = attrs
     const isWhite = gameObj?.orientation === 'white'
+    const checkColor = parseFen(attrs.fen)
+      .chain(setup => Chess.fromSetup(setup))
+      .unwrap(position => position.isCheck() ? position.turn : undefined)
 
     return (
       <div className="mini_board_container">
@@ -43,7 +48,7 @@ const MiniBoard: Mithril.Component<Attrs, State> = {
         <div className="mini_board" oncreate={helper.ontapY(() => this.link())}>
           <div className="mini_board_helper">
             <div className="mini_board_wrapper">
-              {h(ViewOnlyBoard, attrs)}
+              {h(ViewOnlyBoard, {...attrs, check: checkColor})}
             </div>
           </div>
         </div>


### PR DESCRIPTION
Closes #1908. Affects tournament and home screen featured game mini boards.

## Before


https://user-images.githubusercontent.com/569991/141651137-3c3a6ec8-7f76-42c3-8043-729ba32752bb.mov



## After

https://user-images.githubusercontent.com/569991/141651129-6dae1f3e-58cc-4f4a-8531-e1d48c83c830.mov


