### PR TITLE
Shrink correspondence seek row height

### DIFF
--- a/src/styl/home.styl
+++ b/src/styl/home.styl
@@ -202,6 +202,7 @@
   flex-grow 1
   display flex
   flex-flow column nowrap
+  justify-content space-between
   > .corres_create
     flex 0 1 auto
     margin-top 20px
@@ -209,7 +210,7 @@
     justify-content center
 
 .corres_seeks
-  flex 1 1 auto
+  flex 0 1 auto
   text-align left
   font-size 0.8em
   width 100%


### PR DESCRIPTION
Closes #1939. Note that both before and after, a large list of correspondence seeks pushes the "create game" button out of the initial view. The user can still scroll to view the rest of the list and that button.

## Before
### One seek
<img src="https://user-images.githubusercontent.com/569991/144693984-89d7b15b-346d-4cac-bc6c-7d465eb6b91a.png" width="300">

### A few seeks

<img src="https://user-images.githubusercontent.com/569991/144693983-388209f7-a2b0-40e7-950d-11a66981e53f.png" width="300">

### Many seeks

<img src="https://user-images.githubusercontent.com/569991/144693982-e036dc28-3d73-4a5d-844b-f4902da85198.png" width="300">

## After
### One seek
<img src="https://user-images.githubusercontent.com/569991/144694015-0a47b0a4-5aec-4907-ab90-ec5ead654e23.png" width="300">

### A few seeks

<img src="https://user-images.githubusercontent.com/569991/144694030-ed0d0d55-07fa-400e-9f95-bb82ddf76a87.png" width="300">

### Many seeks

<img src="https://user-images.githubusercontent.com/569991/144694034-424e8eb6-66d4-446a-b41c-5af4f43c9661.png" width="300">


