### PR TITLE
Fix anonymous no-clock analysis screen shift

### DIFF
--- a/src/ui/analyse/view/boardView.ts
+++ b/src/ui/analyse/view/boardView.ts
@@ -29,6 +29,12 @@ export function playerBar(ctrl: AnalyseCtrl, color: Color): Mithril.Child {
   const pName = ctrl.playerName(color)
   const isAnonymous = pName === 'Anonymous'
 
+  // Assumes studies without player info do not have clock info
+  if ((ctrl.study && isAnonymous) || (!ctrl.study && ctrl.synthetic)) {
+    return null
+  }
+
+
   const study = ctrl.study && ctrl.study.data
   let title, elo, result: string | undefined
   if (study) {
@@ -44,7 +50,7 @@ export function playerBar(ctrl: AnalyseCtrl, color: Color): Mithril.Child {
   return h('div.analyse-player_bar', {
     className: ctrl.settings.s.smallBoard ? 'halfsize' : ''
   }, [
-    h('div.info', isAnonymous ? null : [
+    h('div.info', isAnonymous ? h.trust('&nbsp') : [
       result ? h('span.result', result) : null,
       h('span.name', (title ? title + ' ' : '') + pName + (elo ? ` (${elo})` : '')),
     ]),


### PR DESCRIPTION
Closes #1874. It's possible to be looking at an anonymous game with clock info for some nodes but with no clock info for the current node. Setting the player name to `&nbsp;` will prevent the screen from shifting between nodes with and without clock info for those games.

This code affects display for all analysis situations, so I've tried to capture all possible scenarios below. The two not listed that I can think of are:
- a non-synthetic anonymous game with no time control, which I don't believe it's possible to create (just tried to do so and was told "you need an account to do that")
- a study with clock info but no player info (don't know if it's possible to have a study with clock info?)

| Situation | Picture | Notes |
| ---- | ---- | ---- |
| Non-synthetic anonymous game | https://user-images.githubusercontent.com/569991/144712139-0e5d6636-3cdb-4e91-bfd6-d0bef7266b52.mov | **No screen jumps when move node has no clock info** - this is the new behavior |
| Study without player info | <img src="https://user-images.githubusercontent.com/569991/144711760-17a9ee43-eaa6-4532-86f3-9c7460912c19.png" width="325"> | Player bars not included, as before |
| Study with player info | <img src="https://user-images.githubusercontent.com/569991/144711801-bda508af-49a2-408b-ac68-280118bf9713.png" width="325"> | Player bars included, as before |
| Synthetic analysis (no player info) | <img src="https://user-images.githubusercontent.com/569991/144711853-065872c1-fac4-4caa-a429-2787abd69473.png" width="325"> | Player bars not included, as before |
| Non-synthetic non-anonymous game | https://user-images.githubusercontent.com/569991/144712244-e4540efc-d1e2-4e60-b491-dd83742d716e.mov | No screen jumps, as before