### PR TITLE
remove unused tournament.me.username

### DIFF
--- a/src/lichess/interfaces/tournament.ts
+++ b/src/lichess/interfaces/tournament.ts
@@ -49,7 +49,6 @@ export interface TournamentClock {
 
 interface TournamentMe {
   rank: number
-  readonly username: string
   readonly withdraw: boolean
 }
 


### PR DESCRIPTION
I'm glad it's unused, that makes the next gen tournament server easier to build!