### PR TITLE
Fix announcement padding on iOS

### DIFF
--- a/src/styl/main.styl
+++ b/src/styl/main.styl
@@ -12,8 +12,7 @@ body
   top 0
   min-height headerHeight
   width 100%
-  padding env(safe-area-inset-top) 0
-  padding-left 0.5em
+  padding env(safe-area-inset-top) 0 0 0.5em
   box-sizing border-box
   background orange
   text-align center


### PR DESCRIPTION
Closes #1970. As noted in the issue, the `env(safe-area-inset-top)` should apply to top padding, but not bottom.

## Before
<img src="https://user-images.githubusercontent.com/569991/148656358-a07a3140-6848-413e-9442-326b027b84a2.png" width="350">

## After
<img src="https://user-images.githubusercontent.com/569991/148656277-acbdf263-457c-4ecd-ace8-f5f97122a27f.png" width="350">