### PR TITLE
Remove unneeded Android theme parameters

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -18,10 +18,5 @@
 
     <style name="AppTheme.NoActionBarLaunch" parent="AppTheme.NoActionBar">
         <item name="android:background">@drawable/launch_splash</item>
-        <item name="android:windowNoTitle">true</item>
-        <item name="android:windowActionBar">false</item>
-        <item name="android:windowFullscreen">true</item>
-        <item name="android:windowContentOverlay">@null</item>
-        <item name="android:windowIsTranslucent">true</item>
     </style>
 </resources>


### PR DESCRIPTION
These aren't doing anything productive, as they're quickly overridden when
`BridgeActivity` resets the theme. Additionally `windowIsTranslucent` may trigger
this Android issue https://issuetracker.google.com/issues/194427611 , when
using 3rd party launchers that support the return to home animation on
Android 11+, the Lichess icon may get stuck on the screen.

Tested on Android 11+ with and without GestureNavContract and with and without dark mode.
Also tested on Android 8.0 to verify this doesn't introduce splash screen issues on older Android versions.
I was unable to find out why these parameters were originally added.