### PR TITLE
Fix tournament header padding on notched devices

### DIFF
--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -41,26 +41,26 @@ PODS:
     - Capacitor
   - CapacitorToast (1.0.6):
     - Capacitor
-  - Firebase/CoreOnly (8.9.1):
-    - FirebaseCore (= 8.9.1)
-  - Firebase/Messaging (8.9.1):
+  - Firebase/CoreOnly (8.10.0):
+    - FirebaseCore (= 8.10.0)
+  - Firebase/Messaging (8.10.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 8.9.0)
-  - FirebaseCore (8.9.1):
+    - FirebaseMessaging (~> 8.10.0)
+  - FirebaseCore (8.10.0):
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.6)
     - GoogleUtilities/Logger (~> 7.6)
-  - FirebaseCoreDiagnostics (8.9.0):
+  - FirebaseCoreDiagnostics (8.10.0):
     - GoogleDataTransport (~> 9.1)
     - GoogleUtilities/Environment (~> 7.6)
     - GoogleUtilities/Logger (~> 7.6)
     - nanopb (~> 2.30908.0)
-  - FirebaseInstallations (8.9.0):
+  - FirebaseInstallations (8.10.0):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/Environment (~> 7.6)
     - GoogleUtilities/UserDefaults (~> 7.6)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseMessaging (8.9.0):
+  - FirebaseMessaging (8.10.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleDataTransport (~> 9.1)
@@ -201,11 +201,11 @@ SPEC CHECKSUMS:
   CapacitorStockfishVariants: 44c1a294c05a342c26023516e7df996edca9d609
   CapacitorStorage: 229dbc333a93764ba0a1b99c4fa22bbb37b47e45
   CapacitorToast: ac17b569d5c4fcffa2be1e4b2da3b3012a02c690
-  Firebase: fb5114cd2bf96e2ff7bcb01d0d9a156cf5fd2f07
-  FirebaseCore: c5aab092d9c4b8efea894946166b04c9d9ef0e68
-  FirebaseCoreDiagnostics: 5daa63f1c1409d981a2d5007daa100b36eac6a34
-  FirebaseInstallations: caa7c8e0d3e2345b8829d2fa9ca1b4dfbf2fcc85
-  FirebaseMessaging: 82c4a48638f53f7b184f3cc9f6cd2cbe533ab316
+  Firebase: 44213362f1dcc52555b935dc925ed35ac55f1b20
+  FirebaseCore: 04186597c095da37d90ff9fd3e53bc61a1ff2440
+  FirebaseCoreDiagnostics: 56fb7216d87e0e6ec2feddefa9d8a392fe8b2c18
+  FirebaseInstallations: 830327b45345ffc859eaa9c17bcd5ae893fd5425
+  FirebaseMessaging: b0aeba17332ee1ee610662b4d1e02a86db82f08f
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleUtilities: 684ee790a24f73ebb2d1d966e9711c203f2a4237
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96

--- a/ios/App/Podfile.lock
+++ b/ios/App/Podfile.lock
@@ -41,26 +41,26 @@ PODS:
     - Capacitor
   - CapacitorToast (1.0.6):
     - Capacitor
-  - Firebase/CoreOnly (8.10.0):
-    - FirebaseCore (= 8.10.0)
-  - Firebase/Messaging (8.10.0):
+  - Firebase/CoreOnly (8.9.1):
+    - FirebaseCore (= 8.9.1)
+  - Firebase/Messaging (8.9.1):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 8.10.0)
-  - FirebaseCore (8.10.0):
+    - FirebaseMessaging (~> 8.9.0)
+  - FirebaseCore (8.9.1):
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.6)
     - GoogleUtilities/Logger (~> 7.6)
-  - FirebaseCoreDiagnostics (8.10.0):
+  - FirebaseCoreDiagnostics (8.9.0):
     - GoogleDataTransport (~> 9.1)
     - GoogleUtilities/Environment (~> 7.6)
     - GoogleUtilities/Logger (~> 7.6)
     - nanopb (~> 2.30908.0)
-  - FirebaseInstallations (8.10.0):
+  - FirebaseInstallations (8.9.0):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/Environment (~> 7.6)
     - GoogleUtilities/UserDefaults (~> 7.6)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseMessaging (8.10.0):
+  - FirebaseMessaging (8.9.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleDataTransport (~> 9.1)
@@ -201,11 +201,11 @@ SPEC CHECKSUMS:
   CapacitorStockfishVariants: 44c1a294c05a342c26023516e7df996edca9d609
   CapacitorStorage: 229dbc333a93764ba0a1b99c4fa22bbb37b47e45
   CapacitorToast: ac17b569d5c4fcffa2be1e4b2da3b3012a02c690
-  Firebase: 44213362f1dcc52555b935dc925ed35ac55f1b20
-  FirebaseCore: 04186597c095da37d90ff9fd3e53bc61a1ff2440
-  FirebaseCoreDiagnostics: 56fb7216d87e0e6ec2feddefa9d8a392fe8b2c18
-  FirebaseInstallations: 830327b45345ffc859eaa9c17bcd5ae893fd5425
-  FirebaseMessaging: b0aeba17332ee1ee610662b4d1e02a86db82f08f
+  Firebase: fb5114cd2bf96e2ff7bcb01d0d9a156cf5fd2f07
+  FirebaseCore: c5aab092d9c4b8efea894946166b04c9d9ef0e68
+  FirebaseCoreDiagnostics: 5daa63f1c1409d981a2d5007daa100b36eac6a34
+  FirebaseInstallations: caa7c8e0d3e2345b8829d2fa9ca1b4dfbf2fcc85
+  FirebaseMessaging: 82c4a48638f53f7b184f3cc9f6cd2cbe533ab316
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleUtilities: 684ee790a24f73ebb2d1d966e9711c203f2a4237
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96

--- a/src/styl/modal.styl
+++ b/src/styl/modal.styl
@@ -16,7 +16,7 @@
     top 0
     left 0
     width 100%
-    height 'calc(%s + env(safe-area-inset-top))' % headerHeight
+    height headerHeight
     background modalDarkHeader
     padding-top: env(safe-area-inset-top);
     > h2


### PR DESCRIPTION
Closes #1979.

Since we're using [the default `box-sizing: content-box`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing), we don't need to adjust the height to account for the padding, which is already set to `env(safe-area-inset-top)`.

## Before

![Simulator Screen Shot - iPhone 11 - 2022-01-14 at 09 22 16](https://user-images.githubusercontent.com/569991/149534263-51b9e04a-7f87-4203-aa8f-053b590b03fd.png)


## After

![Simulator Screen Shot - iPhone 11 - 2022-01-14 at 09 40 28](https://user-images.githubusercontent.com/569991/149534233-20022aa0-1def-4b64-a7ad-eaaa6637ca9c.png)